### PR TITLE
feat(smtp): append sent messages to IMAP Sent folder after send

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,9 @@ Features:
 | `larger_than`     | `largerThan`    | number (KB)      | `LARGER` (converted to bytes)                                                                          |
 | `smaller_than`    | `smallerThan`   | number (KB)      | `SMALLER`                                                                                              |
 | `has_attachment`  | `hasAttachment` | boolean          | Post-pagination filter (IMAP has no native attachment search — applied to current page only)           |
+| `attachment_filename` | `attachmentFilename` | string    | Substring match (case-insensitive) against any attachment filename on the current page                 |
+| `attachment_mimetype` | `attachmentMimetype` | string    | Regex (case-insensitive) applied to each attachment's `type/subtype` on the current page               |
+| `facets`          | `facets`        | string[]         | `search_emails` only — returns bucketed counts by `sender` / `year` / `mailbox`                        |
 | `gmail_raw`       | `gmailRaw`      | string           | Gmail only — passes through to `X-GM-RAW` (Gmail native search syntax). Other filters ignored when set. |
 
 ### Example — "Pines Rd" invoice search
@@ -705,6 +708,50 @@ Notes:
 - When `gmail_raw` is provided, other filters are ignored and a warning lists them.
 - On non-Gmail accounts, `gmail_raw` raises an error explaining the restriction.
 - Full Gmail syntax reference: <https://support.google.com/mail/answer/7190>.
+
+### Attachment filters
+
+When `has_attachment: true` alone returns too much noise, narrow by filename substring or MIME type regex. Both are applied post-pagination on the current page's body-structure fetches (same trade-off as `has_attachment`: if the filter trims the page, fewer items are served and `totalApprox` is set).
+
+```jsonc
+// Narrow a noisy Pines Rd thread to signed PDFs only
+{
+  "account":             "primary",
+  "subject":             "Pines Rd",
+  "attachment_filename": "lease",             // matches "signed_lease_v7.pdf"
+  "attachment_mimetype": "application/pdf"    // regex, case-insensitive
+}
+```
+
+Regex examples:
+
+- `"application/pdf"` — exact MIME
+- `"image/.*"` — any image attachment
+- `"^application/(pdf|zip)$"` — PDFs or zips
+
+Invalid regex patterns raise a `Invalid attachment_mimetype pattern: …` tool error.
+
+### Facets
+
+`search_emails` (only — not `list_emails`) accepts a `facets` array to return bucketed counts across the **full match set** (up to the 5000-UID cap) alongside the paginated page:
+
+```jsonc
+{
+  "account": "primary",
+  "since":   "90d",
+  "facets":  ["sender", "year"]
+}
+```
+
+The response appends a `📊 Facets` block with the top 10 senders and year buckets:
+
+```
+📊 Facets
+  By sender: alice@example.com (42), bob@example.com (15), ...
+  By year:   2025 (52), 2024 (20)
+```
+
+Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. When the match set exceeds **10000 UIDs** facets are skipped with a warning — narrow the query (date range, sender, subject) to unlock them. `"mailbox"` is a reserved single-entry bucket for the current mailbox; cross-account search is coming in a later PR.
 
 ### Performance Notes
 

--- a/README.md
+++ b/README.md
@@ -775,6 +775,18 @@ Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. Whe
 
 Each result in the rendered output is prefixed with `[account-name]` so you can see the source, and the response appends a `⚠️ Warnings` block whenever one or more accounts failed.
 
+#### Automatic mailbox aliasing
+
+Different providers expose different folder structures. Gmail's archive is
+`[Gmail]/All Mail`; cPanel Dovecot uses `INBOX.Archive`; Exchange uses yet
+another path. When you call `search_all_accounts(mailbox="INBOX.Archive")`,
+each account's mailbox list is checked, and if the literal folder doesn't
+exist, the server's SPECIAL-USE flags (`\All`, `\Archive`, `\Sent`, `\Trash`,
+`\Drafts`, `\Junk`) are used to find the equivalent folder automatically.
+Remappings are surfaced in the response as `ℹ️` notices so you can see what
+was actually searched. Mailbox lists are cached per-account for 5 minutes to
+avoid re-LISTing on every call.
+
 ### Saved searches
 
 Define reusable named filter combinations in `config.toml` under `[[searches]]`. Each preset bundles the same parameter set as `search_emails` and can target a single account (`account = "..."`) or fan out across multiple (`accounts = ["a", "b"]`). Run them via `run_preset`.

--- a/README.md
+++ b/README.md
@@ -640,6 +640,78 @@ Features:
 - **Graceful degradation** — Falls back to notify mode if client doesn't support sampling
 - **Resource subscriptions** — Pushes `notifications/resources/updated` for unread counts
 
+## Power Search
+
+`list_emails` and `search_emails` support a rich set of server-side filters translated to native IMAP search criteria. All filters combine with AND; `query` matches as OR across `subject`/`from`/`body`. Snake_case at the tool layer, camelCase in the service layer.
+
+### Supported filters
+
+| Tool param        | Service option  | Type             | IMAP term / behavior                                                                                  |
+|-------------------|-----------------|------------------|-------------------------------------------------------------------------------------------------------|
+| `query`           | `query`         | string           | OR across `SUBJECT` / `FROM` / `BODY`                                                                 |
+| `from`            | `from`          | string           | `FROM` substring                                                                                      |
+| `to`              | `to`            | string           | `TO` substring                                                                                        |
+| `cc`              | `cc`            | string           | `CC` substring                                                                                        |
+| `bcc`             | `bcc`           | string           | `BCC` substring                                                                                       |
+| `subject`         | `subject`       | string           | `SUBJECT` substring                                                                                   |
+| `body`            | `body`          | string           | `BODY` substring                                                                                      |
+| `text`            | `text`          | string           | `TEXT` (headers + body) substring                                                                     |
+| `since`           | `since`         | string           | `SINCE` — delivery date on/after. Accepts ISO 8601, `YYYY-MM-DD`, or relative (`7d`, `2w`, `1m`, `yesterday`, `today`) |
+| `before`          | `before`        | string           | `BEFORE` — delivery date strictly before                                                              |
+| `on`              | `on`            | string           | `ON` — delivery date equals                                                                            |
+| `sent_since`      | `sentSince`     | string           | `SENTSINCE` — header `Date` on/after                                                                  |
+| `sent_before`     | `sentBefore`    | string           | `SENTBEFORE` — header `Date` before                                                                   |
+| `seen`            | `seen`          | boolean          | `SEEN` / `UNSEEN`                                                                                     |
+| `flagged`         | `flagged`       | boolean          | `FLAGGED` / `UNFLAGGED`                                                                               |
+| `answered`        | `answered`      | boolean          | `ANSWERED` / `UNANSWERED`                                                                             |
+| `draft`           | `draft`         | boolean          | `DRAFT` / `UNDRAFT`                                                                                   |
+| `deleted`         | `deleted`       | boolean          | `DELETED` / `UNDELETED`                                                                               |
+| `keyword`         | `keyword`       | string or array  | `KEYWORD` (custom IMAP flag / label)                                                                  |
+| `not_keyword`     | `notKeyword`    | string or array  | `UNKEYWORD`                                                                                           |
+| `header`          | `header`        | object           | `HEADER name value` per entry (e.g. `{ "X-Custom": "foo" }`)                                          |
+| `uids`            | `uids`          | number[] or string | `UID` — filter to a UID set or IMAP range string (`"1:100"`)                                         |
+| `larger_than`     | `largerThan`    | number (KB)      | `LARGER` (converted to bytes)                                                                          |
+| `smaller_than`    | `smallerThan`   | number (KB)      | `SMALLER`                                                                                              |
+| `has_attachment`  | `hasAttachment` | boolean          | Post-pagination filter (IMAP has no native attachment search — applied to current page only)           |
+| `gmail_raw`       | `gmailRaw`      | string           | Gmail only — passes through to `X-GM-RAW` (Gmail native search syntax). Other filters ignored when set. |
+
+### Example — "Pines Rd" invoice search
+
+```jsonc
+// search_emails tool call
+{
+  "account":        "primary",
+  "subject":        "Pines Rd",
+  "body":           "invoice",
+  "since":          "2024-01-01",
+  "before":         "2024-12-31",
+  "has_attachment": true
+}
+```
+
+### Gmail Fast Path
+
+When the account's `imap.host === "imap.gmail.com"`, pass `gmail_raw` for native Gmail search syntax executed entirely server-side. Dramatically faster than client-side filtering for large mailboxes.
+
+```jsonc
+// search_emails on a Gmail account
+{
+  "account":   "gmail",
+  "gmail_raw": "from:alice@example.com has:attachment older_than:30d"
+}
+```
+
+Notes:
+- When `gmail_raw` is provided, other filters are ignored and a warning lists them.
+- On non-Gmail accounts, `gmail_raw` raises an error explaining the restriction.
+- Full Gmail syntax reference: <https://support.google.com/mail/answer/7190>.
+
+### Performance Notes
+
+- **UID cap**: large result sets are capped at **5000 UIDs** before pagination. When truncation happens the response includes a `warning` and the rendered count is prefixed with `~` to indicate `totalApprox`. Narrow the query with more filters (dates, sender, subject) to drop below the cap.
+- **`has_attachment` is post-pagination**: because IMAP has no native attachment search, the filter is now applied only to the current page's body-structure fetches — so a 78k-message folder no longer triggers a full-folder body-structure scan upfront. The trade-off: if the filter trims items on a page, the page serves fewer results and `totalApprox` is set; narrow the query instead of relying on `has_attachment` alone.
+- **Relative date tokens** (`7d`, `2w`, `1m`, `yesterday`, `today`) are evaluated in UTC at call time.
+
 ## API
 
 ### Tools (47)

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ The response appends a `📊 Facets` block with the top 10 senders and year buck
   By year:   2025 (52), 2024 (20)
 ```
 
-Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. When the match set exceeds **10000 UIDs** facets are skipped with a warning — narrow the query (date range, sender, subject) to unlock them. `"mailbox"` is a reserved single-entry bucket for the current mailbox; cross-account search is coming in a later PR.
+Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. When the match set exceeds **10000 UIDs** facets are skipped with a warning — narrow the query (date range, sender, subject) to unlock them. In `search_emails`, `"mailbox"` is a single-entry bucket for the current mailbox. In `search_all_accounts`, the `mailbox` facet is re-keyed by account name, giving a per-account breakdown (e.g. `{ "wgs-usa": 42, "all-pedal": 10 }`).
 
 ### Performance Notes
 
@@ -759,11 +759,57 @@ Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. Whe
 - **`has_attachment` is post-pagination**: because IMAP has no native attachment search, the filter is now applied only to the current page's body-structure fetches — so a 78k-message folder no longer triggers a full-folder body-structure scan upfront. The trade-off: if the filter trims items on a page, the page serves fewer results and `totalApprox` is set; narrow the query instead of relying on `has_attachment` alone.
 - **Relative date tokens** (`7d`, `2w`, `1m`, `yesterday`, `today`) are evaluated in UTC at call time.
 
+### Cross-account search
+
+`search_all_accounts` fans a single query out across multiple accounts in parallel (Promise.allSettled), merges results sorted by date, and tags each item with the originating account name. Partial failures are surfaced as `warnings` — a single bad account does not fail the entire call. Omit the `accounts` field to default to every configured account.
+
+```jsonc
+// Find every "Pines Rd" message across all configured accounts
+{
+  "query":    "Pines Rd",
+  "accounts": ["wgs-usa", "all-pedal"],  // optional — defaults to every account
+  "since":    "90d",
+  "facets":   ["sender", "mailbox"]       // `mailbox` facet is re-keyed by account
+}
+```
+
+Each result in the rendered output is prefixed with `[account-name]` so you can see the source, and the response appends a `⚠️ Warnings` block whenever one or more accounts failed.
+
+### Saved searches
+
+Define reusable named filter combinations in `config.toml` under `[[searches]]`. Each preset bundles the same parameter set as `search_emails` and can target a single account (`account = "..."`) or fan out across multiple (`accounts = ["a", "b"]`). Run them via `run_preset`.
+
+```toml
+[[searches]]
+name        = "pines-lease"
+description = "Pines Rd 2024 lease paperwork across WGS USA + All Pedal"
+accounts    = ["wgs-usa", "all-pedal"]    # cross-account; omit for single-account use
+subject     = "Pines Rd"
+since       = "2024-01-01"
+before      = "2025-01-01"
+has_attachment       = true
+attachment_filename  = "lease"
+facets      = ["sender", "year", "mailbox"]
+
+[[searches]]
+name    = "urgent-flagged"
+account = "primary"                        # single-account variant
+flagged = true
+seen    = false
+```
+
+```jsonc
+// Tool call
+{ "name": "pines-lease", "pageSize": 20 }
+```
+
+`list_presets` appends a `📋 Saved searches (from config.toml)` section so the available names are discoverable at runtime.
+
 ## API
 
-### Tools (47)
+### Tools (49)
 
-#### Read (14)
+#### Read (16)
 
 | Tool | Description |
 |------|-------------|
@@ -774,6 +820,8 @@ Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. Whe
 | `get_emails` | Fetch full content of multiple emails in a single call (max 20) |
 | `get_email_status` | Get read/flag/label state of an email without fetching the body |
 | `search_emails` | Search by keyword across subject, sender, and body |
+| `search_all_accounts` | Fan a search across multiple accounts in parallel; merges + date-sorts results and tags each with its account |
+| `run_preset` | Run a saved search preset defined under `[[searches]]` in config.toml |
 | `download_attachment` | Download an email attachment by filename |
 | `find_email_folder` | Discover the real folder(s) an email resides in (resolves virtual folders) |
 | `extract_contacts` | Extract unique contacts from recent email headers |
@@ -823,7 +871,7 @@ Facets are computed via a single envelope-only IMAP fetch in 500-UID chunks. Whe
 | Tool | Description |
 |------|-------------|
 | `get_watcher_status` | Show IMAP IDLE connections, folders being monitored, and last-seen UIDs |
-| `list_presets` | List available AI triage presets with descriptions and suggested labels |
+| `list_presets` | List available AI triage presets AND saved search presets (from `[[searches]]` in config.toml) |
 | `get_hooks_config` | Show current hooks configuration — preset, rules, and custom instructions |
 | `configure_alerts` | Update alert/notification settings at runtime |
 | `check_notification_setup` | Diagnose desktop notification support and provide setup instructions |

--- a/README.md
+++ b/README.md
@@ -817,11 +817,96 @@ seen    = false
 
 `list_presets` appends a `📋 Saved searches (from config.toml)` section so the available names are discoverable at runtime.
 
+## Export & Attachment Save
+
+Three tools that write directly to disk under `~/Downloads/` (or a caller-supplied path under `$HOME` / `/tmp`). Every path is validated — attempts to write to `/etc`, `/System`, `/usr/bin`, etc. are rejected, and `..` traversal is stripped.
+
+### `export_search`
+
+Run any `search_emails` / `search_all_accounts` query and stream the result set to a **CSV** or **NDJSON** file. The MCP response carries only a tiny summary (path + row count + truncation flag); the bulk of the data lives on disk, so this bypasses the ~25k-token response cap.
+
+```jsonc
+// Export every Pines Rd message across two accounts to CSV
+{
+  "accounts":    ["wgs-usa", "all-pedal"],
+  "subject":     "Pines Rd",
+  "since":       "2024-01-01",
+  "before":      "2025-01-01",
+  "format":      "csv",
+  "max_rows":    5000,
+  "destination": "/Users/me/Downloads/pines-rd-2024.csv"
+}
+```
+
+Default CSV columns (snake_case headers): `id`, `account`, `date`, `from`, `subject`, `labels`, `attachments`, `has_attachments`, `seen`, `flagged`. Pass `columns` to pick a subset; available columns are `id`, `account`, `date`, `from`, `to`, `subject`, `flags`, `labels`, `attachments`, `preview`, `size`.
+
+- `attachments` serializes as `filename1.pdf|filename2.png`
+- `labels` serializes as `label1|label2`
+- `from` serializes as `"Name <addr@domain>"`
+- All escaping follows RFC 4180 (quote fields containing `",\n\r`, double embedded quotes)
+
+NDJSON mode emits one `JSON.stringify(EmailMeta)` per line — the `columns` parameter is ignored and the full structured record (including attachments array) is dumped.
+
+`max_rows` defaults to 5000 (hard ceiling 50 000). When the underlying match set is larger the file is truncated and the response sets `truncated: true`.
+
+### `save_attachment`
+
+Write a single attachment to disk without the ~5 MB ceiling and base64 hop of `download_attachment`. The file is piped from `imapflow` straight into `fs.createWriteStream` — no intermediate buffer, no MCP-response byte budget.
+
+```jsonc
+// Save a single lease PDF to ~/Downloads
+{
+  "account":    "wgs-usa",
+  "emailId":    "12345",
+  "mailbox":    "INBOX",
+  "filename":   "signed_lease_v7.pdf",
+  "open":       true   // optional — spawns `open <path>` on macOS after save
+}
+```
+
+Contrast:
+
+| | `download_attachment` (legacy) | `save_attachment` (new) |
+|---|---|---|
+| Response payload | base64-encoded bytes | `{ path, size, mimeType }` summary |
+| Size limit | 5 MB | None |
+| MCP token budget | Consumes ~25k tokens for typical PDFs | Constant-size response |
+| Use case | Inline preview, AI analysis | Bulk save, user-facing download |
+
+Auto-collision suffix: if `lease.pdf` exists the tool writes `lease-1.pdf`, `lease-2.pdf`, etc. Pass `overwrite: true` to opt in.
+
+### `save_all_attachments_from_search`
+
+Run a search and sweep every matching attachment into a dated folder. Great for year-end lease-PDF audits, vendor invoice collections, monthly statement exports.
+
+```jsonc
+// Year-end Pines Rd lease-PDF sweep — 2024, across two accounts,
+// filtered to PDFs whose filename mentions "lease", bucketed by month.
+{
+  "accounts":            ["wgs-usa", "all-pedal"],
+  "subject":             "Pines Rd",
+  "since":               "2024-01-01",
+  "before":              "2025-01-01",
+  "attachment_filename": "lease",
+  "attachment_mimetype": "application/pdf",
+  "organize_by":         "date"
+}
+```
+
+`organize_by` controls the subfolder layout under the destination:
+
+- `flat` — all files in a single folder (default)
+- `date` — `YYYY-MM/` buckets based on each email's date
+- `sender` — bucketed by sender domain (e.g. `example.com/`)
+- `account` — bucketed by originating account name (useful for multi-account sweeps)
+
+Default destination is `~/Downloads/email-attachments-<ISO-ts>/`. Per-email errors are collected in `errors[]` rather than aborting the whole run — you get a summary with `files_saved`, `total_size`, `skipped`, and the error list.
+
 ## API
 
-### Tools (49)
+### Tools (52)
 
-#### Read (16)
+#### Read (19)
 
 | Tool | Description |
 |------|-------------|
@@ -834,7 +919,10 @@ seen    = false
 | `search_emails` | Search by keyword across subject, sender, and body |
 | `search_all_accounts` | Fan a search across multiple accounts in parallel; merges + date-sorts results and tags each with its account |
 | `run_preset` | Run a saved search preset defined under `[[searches]]` in config.toml |
-| `download_attachment` | Download an email attachment by filename |
+| `export_search` | Run a search and stream the result set to a CSV or NDJSON file under `~/Downloads/` (bypasses MCP response byte budget) |
+| `download_attachment` | Download an email attachment by filename (base64 in response; ≤5MB) |
+| `save_attachment` | Save an attachment directly to disk — no base64 hop, no size limit |
+| `save_all_attachments_from_search` | Run a search and download every matching attachment into a dated folder (with optional filename/mimetype filter) |
 | `find_email_folder` | Discover the real folder(s) an email resides in (resolves virtual folders) |
 | `extract_contacts` | Extract unique contacts from recent email headers |
 | `get_thread` | Reconstruct a conversation thread via References/In-Reply-To |

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,108 @@
+# email-mcp example configuration
+# Copy to ~/.config/email-mcp/config.toml and fill in your credentials.
+# Lock down permissions after editing: chmod 600 ~/.config/email-mcp/config.toml
+
+[settings]
+rate_limit = 10
+
+# ============================================================
+# cPanel / Dovecot HOSTED ACCOUNTS
+#
+# IMPORTANT — sent_folder override:
+# cPanel servers typically maintain two "Sent" folders:
+#
+#   INBOX.Sent          — has the IMAP SPECIAL-USE \Sent attribute
+#   INBOX.Sent Messages — the folder Mac Mail maps to its sent mailbox
+#                         (paper airplane icon in the sidebar)
+#
+# email-mcp auto-detection correctly picks INBOX.Sent via RFC 6154
+# SPECIAL-USE, but Mac Mail uses INBOX.Sent Messages. Without the
+# override below, sent copies land in a folder Mac Mail displays as
+# a plain folder, not the paper airplane one.
+#
+# Fix: always set sent_folder = "INBOX.Sent Messages" for cPanel accounts.
+# See docs/troubleshooting-sent-folder.md for full details.
+# ============================================================
+
+[[accounts]]
+name = "account-one"
+email = "example@sample.com"
+full_name = "Your Name"
+password = "________"
+sent_folder = "INBOX.Sent Messages"
+
+[accounts.imap]
+host = "your-cpanel-server.com"
+port = 993
+tls = true
+
+[accounts.smtp]
+host = "your-cpanel-server.com"
+port = 465
+tls = true
+
+[[accounts]]
+name = "account-two"
+email = "example2@sample.com"
+full_name = "Your Name"
+password = "________"
+sent_folder = "INBOX.Sent Messages"
+
+[accounts.imap]
+host = "your-cpanel-server.com"
+port = 993
+tls = true
+
+[accounts.smtp]
+host = "your-cpanel-server.com"
+port = 465
+tls = true
+
+# ============================================================
+# GMAIL ACCOUNTS
+# Must use a Gmail App Password — not your regular password.
+# Generate one at: https://myaccount.google.com/apppasswords
+#
+# No sent_folder override needed — Gmail auto-saves sent mail
+# server-side via SMTP. email-mcp skips the IMAP append for Gmail.
+# ============================================================
+
+[[accounts]]
+name = "gmail"
+email = "example@gmail.com"
+full_name = "Your Name"
+password = "________"
+
+[accounts.imap]
+host = "imap.gmail.com"
+port = 993
+tls = true
+
+[accounts.smtp]
+host = "smtp.gmail.com"
+port = 465
+tls = true
+
+# ============================================================
+# iCLOUD ACCOUNTS
+# Must use an Apple App-Specific Password — not your Apple ID password.
+# Generate one at: https://appleid.apple.com -> Sign-In and Security
+#                  -> App-Specific Passwords
+# ============================================================
+
+# [[accounts]]
+# name = "icloud"
+# email = "example@icloud.com"
+# full_name = "Your Name"
+# password = "________"
+#
+# [accounts.imap]
+# host = "imap.mail.me.com"
+# port = 993
+# tls = true
+#
+# [accounts.smtp]
+# host = "smtp.mail.me.com"
+# port = 587
+# tls = false
+# starttls = true

--- a/docs/troubleshooting-sent-folder.md
+++ b/docs/troubleshooting-sent-folder.md
@@ -1,0 +1,108 @@
+# Troubleshooting: Sent Mail Appears in Wrong Folder
+
+## Symptom
+
+After sending an email through email-mcp, the sent copy appears in a folder that
+Mac Mail displays with a plain folder icon — not the folder with the paper airplane
+icon that Mac Mail uses as its native Sent mailbox. Both folders may appear with
+the same label ("Sent") in the Mac Mail sidebar.
+
+## Root Cause
+
+cPanel/Dovecot servers typically expose **two** sent-related folders:
+
+| IMAP Path | IMAP Name | specialUse attribute | Mac Mail display |
+|-----------|-----------|---------------------|-----------------|
+| `INBOX.Sent` | Sent | `\Sent` (RFC 6154 SPECIAL-USE) | "Sent" — plain folder icon |
+| `INBOX.Sent Messages` | Sent Messages | *(none)* | "Sent" — paper airplane icon |
+
+The discrepancy arises because:
+
+1. **Mac Mail** configured `INBOX.Sent Messages` as the sent mailbox when the
+   account was first added — likely before `INBOX.Sent` existed on the server.
+   Mac Mail's paper airplane icon follows whatever folder it has designated as the
+   sent mailbox in its own preferences, not the IMAP SPECIAL-USE attribute.
+
+2. **email-mcp** uses the standard RFC 6154 SPECIAL-USE detection algorithm:
+   it calls `IMAP LIST` and looks for a mailbox flagged with `\Sent`. On cPanel
+   servers this resolves to `INBOX.Sent` — technically correct per the standard,
+   but not the folder Mac Mail is watching.
+
+The result: email-mcp appends sent copies to `INBOX.Sent`; Mac Mail reads sent
+mail from `INBOX.Sent Messages`. They never overlap.
+
+## Fix
+
+Use the `sent_folder` config key to pin each cPanel account directly to
+`INBOX.Sent Messages`, bypassing auto-detection entirely:
+
+```toml
+[[accounts]]
+name = "my-account"
+email = "example@sample.com"
+password = "________"
+sent_folder = "INBOX.Sent Messages"   # <-- add this line
+
+[accounts.imap]
+host = "your-cpanel-server.com"
+port = 993
+tls = true
+```
+
+Apply this to every account hosted on cPanel. Gmail and iCloud do not need it:
+
+- **Gmail** — auto-saves sent mail server-side via SMTP; email-mcp skips the
+  IMAP append entirely for Gmail accounts.
+- **iCloud** — uses standard SPECIAL-USE correctly; no mismatch observed.
+
+See `config.example.toml` in the repo root for a complete template with this
+setting pre-applied to the cPanel account stanzas.
+
+## Verifying Your Folder Names
+
+If you are on a different mail host and want to see exactly what folders and
+SPECIAL-USE attributes your server exposes, run this one-off debug script from
+the repo root:
+
+```js
+// debug-folders.mjs  (delete after use — do not commit)
+import { ImapFlow } from 'imapflow';
+
+const client = new ImapFlow({
+  host: 'your-imap-host.com',
+  port: 993,
+  secure: true,
+  auth: { user: 'you@example.com', pass: 'yourpassword' },
+  logger: false,
+});
+
+await client.connect();
+for (const mb of await client.list('', '*')) {
+  console.log(`${mb.path}  specialUse=${mb.specialUse ?? '(none)'}  flags=${[...(mb.flags ?? [])].join(',')}`);
+}
+await client.logout();
+```
+
+```bash
+node debug-folders.mjs
+```
+
+Look for the folder that Mac Mail shows with the paper airplane icon and use its
+`path` value as `sent_folder` in your config.
+
+## email-mcp Sent Folder Resolution Order
+
+For reference, `resolveSentFolder()` in `src/services/imap.service.ts` tries
+these in order:
+
+1. **Config override** — if `sent_folder` is set in `config.toml`, use it
+   immediately (no server query).
+2. **RFC 6154 SPECIAL-USE** — find the mailbox with `specialUse === '\Sent'`
+   from the IMAP LIST response.
+3. **Common name fallback** — check for `INBOX.Sent`, `Sent`, `Sent Items`,
+   `Sent Mail`, `[Gmail]/Sent Mail`, `INBOX.Sent Items`, `INBOX.Sent Messages`
+   in that order.
+
+On cPanel hosts, step 2 resolves to `INBOX.Sent` (which has the SPECIAL-USE
+flag) rather than `INBOX.Sent Messages` (which does not). The config override
+in step 1 is the correct fix.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10365 @@
+{
+  "name": "@codefuturist/email-mcp",
+  "version": "0.2.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@codefuturist/email-mcp",
+      "version": "0.2.1",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@clack/prompts": "^1.0.1",
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "imapflow": "^1.2.9",
+        "node-ical": "^0.25.2",
+        "nodemailer": "^8.0.1",
+        "smol-toml": "^1.6.0",
+        "zod": "^4.3.6"
+      },
+      "bin": {
+        "email-mcp": "dist/main.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.2",
+        "@eslint/compat": "^2.0.2",
+        "@eslint/js": "^9.39.2",
+        "@types/node": "^25.2.3",
+        "@types/nodemailer": "^7.0.10",
+        "@vitest/coverage-v8": "^4.0.18",
+        "eslint": "^9.39.2",
+        "eslint-config-airbnb-extended": "^3.0.1",
+        "lefthook": "^2.1.1",
+        "testcontainers": "^11.12.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
+      "integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.6",
+        "@biomejs/cli-darwin-x64": "2.4.6",
+        "@biomejs/cli-linux-arm64": "2.4.6",
+        "@biomejs/cli-linux-arm64-musl": "2.4.6",
+        "@biomejs/cli-linux-x64": "2.4.6",
+        "@biomejs/cli-linux-x64-musl": "2.4.6",
+        "@biomejs/cli-win32-arm64": "2.4.6",
+        "@biomejs/cli-win32-x64": "2.4.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
+      "integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
+      "integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
+      "integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
+      "integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
+      "integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
+      "integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
+      "integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
+      "integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@clack/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+      "license": "MIT",
+      "dependencies": {
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+      "integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "1.1.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.0.3.tgz",
+      "integrity": "sha512-SjIJhGigp8hmd1YGIBwh7Ovri7Kisl42GYFjrOyHhtfYGGoLW6teYi/5p8W50KSsawUPpuLOSmsq1bD0NGQLBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^8.40 || 9 || 10"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stylistic/eslint-plugin": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+      "integrity": "sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/types": "^8.56.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "estraverse": "^5.3.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.4.0.tgz",
+      "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
+      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/type-utils": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.57.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
+      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
+      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
+      "integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.0.tgz",
+      "integrity": "sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.21.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001777",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confusing-browser-globals": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
+      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.1.tgz",
+      "integrity": "sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.6.tgz",
+      "integrity": "sha512-ens7BiayssQz/uAxGzH8zGXCtiV24rRWXdjNha5V4zSOcxmAZsfGVm/PPFbwQdqEkDnhG+SyR9E3zSHUbOKXBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.9.tgz",
+      "integrity": "sha512-iND4mcOWhPaCNh54WmK/KoSb35AFqPAUWFMffTQcp52uQt36b5uNwEJTSXntJZBbeGad72Crbi/hvDIv6us/6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.6",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-japanese": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
+      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.1",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-compat-utils/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-config-airbnb-extended": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-extended/-/eslint-config-airbnb-extended-3.0.1.tgz",
+      "integrity": "sha512-JUVAh/tqLx99AFPmjXl5nalD6wrv6AD2muilieUJZG/uCjc89O93upoIcdB9221fTrcBdZAQ6f1jbyda1vcJ+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "^16.1.4",
+        "@stylistic/eslint-plugin": "^5.7.0",
+        "confusing-browser-globals": "^1.0.11",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-import-x": "^4.16.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-n": "^17.23.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.0.1",
+        "globals": "^17.0.0",
+        "typescript-eslint": "^8.53.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/eslint-config-airbnb-extended/node_modules/globals": {
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
+      "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.35.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.0.1",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "17.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.24.0.tgz",
+      "integrity": "sha512-/gC7/KAYmfNnPNOb3eu8vw+TdVnV0zhdQwexsw6FLXbhzroVj20vRn2qL8lDWDGnAQ2J8DhdfvXxX9EoxvERvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3",
+        "ts-declaration-location": "^1.0.6"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.23.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imapflow": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.2.13.tgz",
+      "integrity": "sha512-yQJnYdpnt2LMSjeJ4iSGvbVURmKrlmJxkbPgGfjT4v9ImTo49jIAkfKbtEQnsBT1euQyHHVCOL/y5zz0BDLUKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zone-eu/mailsplit": "5.4.8",
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1",
+        "nodemailer": "8.0.2",
+        "pino": "10.3.1",
+        "socks": "2.8.7"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.1.tgz",
+      "integrity": "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lefthook": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.1.3.tgz",
+      "integrity": "sha512-2W8PP/EGCvyS/x+Xza0Lgvn/EM3FKnr6m6xkfzpl6RKHl8TwPvs9iYZFQL99CnWTTvO+1mtQvIxGE/bD05038Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "2.1.3",
+        "lefthook-darwin-x64": "2.1.3",
+        "lefthook-freebsd-arm64": "2.1.3",
+        "lefthook-freebsd-x64": "2.1.3",
+        "lefthook-linux-arm64": "2.1.3",
+        "lefthook-linux-x64": "2.1.3",
+        "lefthook-openbsd-arm64": "2.1.3",
+        "lefthook-openbsd-x64": "2.1.3",
+        "lefthook-windows-arm64": "2.1.3",
+        "lefthook-windows-x64": "2.1.3"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-2.1.3.tgz",
+      "integrity": "sha512-VMSQK5ZUh66mKrEpHt5U81BxOg5xAXLoLZIK6e++4uc28tj8zGBqV9+tZqSRElXXzlnHbfdDVCMaKlTuqUy0Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-2.1.3.tgz",
+      "integrity": "sha512-4QhepF4cf+fa7sDow29IEuCfm/6LuV+oVyQGpnr5it1DEZIEEoa6vdH/x4tutYhAg/HH7I2jHq6FGz96HRiJEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-2.1.3.tgz",
+      "integrity": "sha512-kysx/9pjifOgcTZOj1bR0i74FAbMv3BDfrpZDKniBOo4Dp0hXhyOtUmRn4nWKL0bN+cqc4ZePAq4Qdm4fxWafA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-2.1.3.tgz",
+      "integrity": "sha512-TLuPHQNg6iihShchrh5DrHvoCZO8FajZBMAEwLIKWlm6bkCcXbYNxy4dBaVK8lzHtS/Kv1bnH0D3BcK65iZFVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-2.1.3.tgz",
+      "integrity": "sha512-e5x4pq1aZAXc0C642V4HaUoKtcHVmGW1HBIDNfWUhtsThBKjhZBXPspecaAHIRA/8VtsXS3RnJ4VhQpgfrCbww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-2.1.3.tgz",
+      "integrity": "sha512-yeVAiV5hoE6Qq8dQDB4XC14x4N9mhn+FetxzqDu5LVci0/sOPqyPq2b0YUtNwJ1ZUKawTz4I/oqnUsHkQrGH0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-2.1.3.tgz",
+      "integrity": "sha512-8QVvRxIosV6NL2XrbifOPGVhMFE43h02BUNEHYhZhyad7BredfAakg9dA9J/NO0I3eMdvCYU50ubFyDGIqUJog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-2.1.3.tgz",
+      "integrity": "sha512-YTS9qeW9PzzKg9Rk55mQprLIl1OdAIIjeOH8DF+MPWoAPkRqeUyq8Q2Bdlf3+Swy+kJOjoiU1pKvpjjc8upv9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-2.1.3.tgz",
+      "integrity": "sha512-Nlp80pWyF67GmxgM5NQmL7JTTccbJAvCNtS5QwHmKq3pJ9Xi0UegP9pGME520n06Rhp+gX7H4boXhm2D5hAghg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-2.1.3.tgz",
+      "integrity": "sha512-KByBhvqgUNhjO/03Mr0y66D9B1ZnII7AB0x17cumwHMOYoDaPJh/AlgmEduqUpatqli3lnFzWD0DUkAY6pq/SA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/libbase64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
+      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
+      "license": "MIT"
+    },
+    "node_modules/libmime": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
+      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.6.3",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
+      }
+    },
+    "node_modules/libmime/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libqp": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
+      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+      "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-ical": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.25.5.tgz",
+      "integrity": "sha512-hj1I+kV38EXdhMB9Sh9phtvdzeJML/HvYbiKqBqcET1O2JiFmJnvpEWISNLA5nUeCWQAaTqiDhZH4uwUTG2Vdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule-temporal": "^1.4.7",
+        "temporal-polyfill": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
+      "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/rrule-temporal": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.5.1.tgz",
+      "integrity": "sha512-mV82lZ7OzMOXX5g+SCR8FWRMSvhTnPSznjQ2Vguezjz1nEPEv/Ap/Z/FsIZ/AxA15M9X99m05911/MCXFY+FsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.0.tgz",
+      "integrity": "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
+      "integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.0.tgz",
+      "integrity": "sha512-qNsTkX9K8hi+FHDfHmf22e/OGuXmfBm9RqNismxBrnSmZVJKegQ+HYYXT+R7Ha8F/YSm2Y34vmzD4cxMu2u95g==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.0"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.0.tgz",
+      "integrity": "sha512-n+noVpIqz4hYgFSMOSiINNOUOMFtV5cZQNCmmszA6GiVFVRt3G7AqVyhXjhCSmowvQn+NsGn+jMDMKJYHd3bSQ==",
+      "license": "ISC"
+    },
+    "node_modules/testcontainers": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.12.0.tgz",
+      "integrity": "sha512-VWtH+UQejVYYvb53ohEZRbx2naxyDvwO9lQ6A0VgmVE2Oh8r9EF09I+BfmrXpd9N9ntpzhao9di2yNwibSz5KA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.3.1",
+        "dockerode": "^4.0.9",
+        "get-port": "^7.1.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.1",
+        "tmp": "^0.2.5",
+        "undici": "^7.22.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.0.tgz",
+      "integrity": "sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.57.0",
+        "@typescript-eslint/parser": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    }
+  }
+}

--- a/src/__integration__/cross-account.integration.test.ts
+++ b/src/__integration__/cross-account.integration.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Integration tests for cross-account search + saved-search presets.
+ *
+ * GreenMail ships with multiple pre-provisioned users (test, bob, alice),
+ * so we can spin up a single ConnectionManager wired to two accounts and
+ * exercise `searchAcrossAccounts` end-to-end.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { loadConfig } from '../config/loader.js';
+import ConnectionManager from '../connections/manager.js';
+import ImapService from '../services/imap.service.js';
+import { SearchPresetRegistry } from '../services/search-presets.js';
+import {
+  buildSecondTestAccount,
+  buildTestAccount,
+  getGreenMailPorts,
+  seedEmail,
+  TEST_ACCOUNT_NAME,
+  waitForDelivery,
+} from './helpers/index.js';
+
+const SECOND_ACCOUNT_NAME = 'integration-2';
+
+describe('Cross-account search + saved-search presets (integration)', () => {
+  let connections: ConnectionManager;
+  let imapService: ImapService;
+
+  // Use a unique subject prefix per run so we don't collide with other
+  // integration tests sharing the same GreenMail container.
+  const MARKER = `xacct-${Date.now()}`;
+
+  beforeAll(async () => {
+    const accountA = buildTestAccount();
+    const accountB = buildSecondTestAccount();
+    connections = new ConnectionManager([accountA, accountB]);
+    imapService = new ImapService(connections);
+
+    // Seed into both mailboxes using the helper (helper derives the sender
+    // username from the from address to pick the right GreenMail user).
+    // test@localhost — account A recipient.
+    await seedEmail({ to: 'test@localhost', subject: `${MARKER} alpha` });
+    await seedEmail({ to: 'test@localhost', subject: `${MARKER} beta` });
+    // bob@localhost — account B recipient.
+    await seedEmail({ to: 'bob@localhost', subject: `${MARKER} alpha` });
+    await seedEmail({ to: 'bob@localhost', subject: `${MARKER}-unique bob-only` });
+    // Give GreenMail a bit longer for the two-mailbox fan-out to settle.
+    await waitForDelivery(1500);
+  });
+
+  afterAll(async () => {
+    await connections.closeAll();
+  });
+
+  // --------------------------------------------------------------------------
+  // searchAcrossAccounts — happy path
+  // --------------------------------------------------------------------------
+
+  describe('searchAcrossAccounts — merged results', () => {
+    it('returns a merged list with .account stamps from both accounts', async () => {
+      const result = await imapService.searchAcrossAccounts(
+        [TEST_ACCOUNT_NAME, SECOND_ACCOUNT_NAME],
+        '',
+        { subject: MARKER, pageSize: 50 },
+      );
+
+      // Both accounts should contribute to the merged set (3 of the 4 seeded
+      // messages match the marker — 2 on test, 1 on bob).
+      expect(result.items.length).toBeGreaterThanOrEqual(3);
+      const accountsSeen = new Set(result.items.map((e) => e.account));
+      expect(accountsSeen.has(TEST_ACCOUNT_NAME)).toBe(true);
+      expect(accountsSeen.has(SECOND_ACCOUNT_NAME)).toBe(true);
+
+      // No partial failures expected when both accounts are healthy.
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it('search targeting only bob returns bob-exclusive subjects', async () => {
+      const result = await imapService.searchAcrossAccounts(
+        [TEST_ACCOUNT_NAME, SECOND_ACCOUNT_NAME],
+        '',
+        { subject: `${MARKER}-unique`, pageSize: 50 },
+      );
+
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      // Every matching item should come from the second account (bob's mailbox).
+      for (const item of result.items) {
+        expect(item.account).toBe(SECOND_ACCOUNT_NAME);
+      }
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Partial-failure semantics
+  // --------------------------------------------------------------------------
+
+  describe('searchAcrossAccounts — partial failure', () => {
+    let localConnections: ConnectionManager;
+    let localImap: ImapService;
+
+    beforeAll(() => {
+      // Build a bogus second account with invalid credentials so the fan-out
+      // hits a real auth failure on B while A still works.
+      const { host, imapPort, smtpPort } = getGreenMailPorts();
+      const goodAccount = buildTestAccount({ name: 'partial-good' });
+      const badAccount = {
+        name: 'partial-bad',
+        email: 'nobody@localhost',
+        fullName: 'Broken Account',
+        username: 'does-not-exist',
+        password: 'wrong-password',
+        imap: { host, port: imapPort, tls: false, starttls: false, verifySsl: false },
+        smtp: { host, port: smtpPort, tls: false, starttls: false, verifySsl: false },
+      };
+      localConnections = new ConnectionManager([goodAccount, badAccount]);
+      localImap = new ImapService(localConnections);
+    });
+
+    afterAll(async () => {
+      await localConnections.closeAll();
+    });
+
+    it('returns partial results plus warnings when one account fails auth', async () => {
+      const result = await localImap.searchAcrossAccounts(['partial-good', 'partial-bad'], '', {
+        subject: MARKER,
+        pageSize: 50,
+      });
+
+      // Good account should still surface items.
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      expect(result.items.every((e) => e.account === 'partial-good')).toBe(true);
+
+      // Bad account should appear as a warning entry, not a thrown error.
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings?.some((w) => w.account === 'partial-bad')).toBe(true);
+
+      // Human-readable warning summary should mention the failing account.
+      expect(result.warning).toMatch(/partial-bad/);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Saved-search preset round-trip
+  // --------------------------------------------------------------------------
+
+  describe('run_preset round-trip via config loader', () => {
+    let tmpDir: string;
+    let registry: SearchPresetRegistry;
+
+    beforeAll(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'email-mcp-preset-it-'));
+      const { host, imapPort, smtpPort } = getGreenMailPorts();
+
+      // Note: Zod's email validator rejects "test@localhost" (needs a TLD).
+      // We use a well-formed placeholder email while keeping username/password
+      // aligned with GreenMail's test user.
+      const toml = `
+[[accounts]]
+name = "${TEST_ACCOUNT_NAME}"
+email = "test@example.com"
+username = "test"
+password = "test"
+
+[accounts.imap]
+host = "${host}"
+port = ${imapPort}
+tls = false
+verify_ssl = false
+
+[accounts.smtp]
+host = "${host}"
+port = ${smtpPort}
+tls = false
+verify_ssl = false
+
+[[searches]]
+name = "alpha-marker"
+description = "Marker preset round-trip"
+account = "${TEST_ACCOUNT_NAME}"
+subject = "${MARKER}"
+`;
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(configPath, toml, 'utf-8');
+
+      const config = await loadConfig(configPath);
+      expect(config.searches).toHaveLength(1);
+      expect(config.searches[0].name).toBe('alpha-marker');
+      expect(config.searches[0].subject).toBe(MARKER);
+
+      registry = new SearchPresetRegistry(config.searches);
+    });
+
+    afterAll(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('preset loaded from TOML can be executed via searchEmails', async () => {
+      const preset = registry.get('alpha-marker');
+      if (!preset) throw new Error('preset should have been registered in beforeAll');
+      expect(preset.account).toBe(TEST_ACCOUNT_NAME);
+      if (!preset.account) throw new Error('preset.account should be set in the TOML');
+
+      // Run the preset's filters directly against searchEmails — same codepath
+      // run_preset uses internally.
+      const result = await imapService.searchEmails(preset.account, preset.query ?? '', {
+        subject: preset.subject,
+        pageSize: 50,
+      });
+
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      for (const item of result.items) {
+        expect(item.subject).toContain(MARKER);
+      }
+    });
+  });
+});

--- a/src/__integration__/cross-account.integration.test.ts
+++ b/src/__integration__/cross-account.integration.test.ts
@@ -56,6 +56,42 @@ describe('Cross-account search + saved-search presets (integration)', () => {
   });
 
   // --------------------------------------------------------------------------
+  // Auto-remap via SPECIAL-USE — Phase 3 follow-on
+  // --------------------------------------------------------------------------
+
+  describe('searchAcrossAccounts — SPECIAL-USE auto-remap', () => {
+    // GreenMail's IMAP server does not natively honor SPECIAL-USE flags on
+    // `CREATE` — mailboxes created with `specialUse: ['\\Archive']` come back
+    // in LIST without any special-use marker. This integration test therefore
+    // exercises only what GreenMail can demonstrate end-to-end: when account
+    // B does NOT have a literal match for the requested mailbox and no
+    // mailbox on that account carries an equivalent SPECIAL-USE flag, the
+    // account is skipped with a hard warning (⚠️ path), and the good account
+    // still returns its results.
+    //
+    // Unit coverage (see imap.service.test.ts + mailbox-resolver.test.ts)
+    // exercises the happy remap path where a real \All flag is present.
+
+    // Skipped: GreenMail's IMAP server does not honor SPECIAL-USE flags on
+    // mailbox CREATE, so we cannot seed a `\All`-flagged folder to exercise
+    // the happy remap path end-to-end. This behaviour is fully covered by
+    // the unit tests in mailbox-resolver.test.ts + imap.service.test.ts.
+    it.skip('remaps mailbox via \\All when literal is missing (requires SPECIAL-USE — GreenMail limitation)', async () => {
+      // No-op; see rationale above.
+    });
+
+    it('all-accounts-skipped path: throws when no account has literal or remap match', async () => {
+      await expect(
+        imapService.searchAcrossAccounts([TEST_ACCOUNT_NAME, SECOND_ACCOUNT_NAME], '', {
+          mailbox: 'INBOX.DefinitelyDoesNotExist',
+          subject: MARKER,
+          pageSize: 50,
+        }),
+      ).rejects.toThrow(/All 2 accounts failed/);
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // searchAcrossAccounts — happy path
   // --------------------------------------------------------------------------
 

--- a/src/__integration__/export.integration.test.ts
+++ b/src/__integration__/export.integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Integration tests for PR 4 — export_search + save_attachment +
+ * save_all_attachments_from_search.
+ *
+ * Each test seeds emails via GreenMail, then exercises the service layer
+ * directly (the MCP tool wrappers are thin shims around these calls).
+ */
+
+/* eslint-disable n/no-sync -- tests use sync fs helpers for setup/teardown */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { writeExport } from '../tools/export.tool.js';
+import type { TestServices } from './helpers/index.js';
+import {
+  buildTestAccount,
+  createTestServices,
+  seedEmail,
+  seedEmails,
+  seedEmailWithAttachment,
+  TEST_ACCOUNT_NAME,
+  waitForDelivery,
+} from './helpers/index.js';
+
+const PDF_MAGIC = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]); // %PDF-1.4
+
+describe('PR 4 — export + attachment save', () => {
+  let services: TestServices;
+  let workDir: string;
+
+  beforeAll(() => {
+    services = createTestServices(buildTestAccount());
+  });
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'pr4-export-'));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await services.connections.closeAll();
+  });
+
+  // ---------------------------------------------------------------------------
+  // save_attachment (service: saveAttachmentToDisk)
+  // ---------------------------------------------------------------------------
+  describe('saveAttachmentToDisk', () => {
+    it('writes a seeded attachment to disk; bytes match the fixture', async () => {
+      const subject = `save-att-${Date.now()}`;
+      await seedEmailWithAttachment('seed.pdf', PDF_MAGIC.toString('base64'), { subject });
+      await waitForDelivery();
+
+      // Find the seeded email
+      const list = await services.imapService.listEmails(TEST_ACCOUNT_NAME, { subject });
+      expect(list.items.length).toBeGreaterThanOrEqual(1);
+      const emailId = list.items[0].id;
+
+      const result = await services.imapService.saveAttachmentToDisk(
+        TEST_ACCOUNT_NAME,
+        emailId,
+        'INBOX',
+        'seed.pdf',
+        workDir,
+      );
+
+      expect(result.path).toBe(join(workDir, 'seed.pdf'));
+      expect(result.size).toBeGreaterThan(0);
+      const onDisk = readFileSync(result.path);
+      // The seeded file content is the base64-decoded form of the payload we passed
+      // above. For text attachments GreenMail preserves the raw content; the test
+      // just asserts non-zero bytes and that the file is readable.
+      expect(onDisk.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // export_search (service: searchForExport + writeExport helper)
+  // ---------------------------------------------------------------------------
+  describe('searchForExport + writeExport', () => {
+    it('exports CSV with header + N data rows for N seeded messages', async () => {
+      const subject = `csv-export-${Date.now()}`;
+      await seedEmails(5, { subject });
+      await waitForDelivery();
+
+      const { items, truncated } = await services.imapService.searchForExport(
+        null,
+        TEST_ACCOUNT_NAME,
+        '',
+        { mailbox: 'INBOX', subject, maxRows: 100 },
+      );
+      expect(truncated).toBe(false);
+      expect(items.length).toBeGreaterThanOrEqual(5);
+
+      const dest = join(workDir, 'export.csv');
+      const rows = await writeExport({
+        format: 'csv',
+        items,
+        columns: ['id', 'subject', 'from'],
+        destination: dest,
+      });
+
+      expect(rows).toBe(items.length);
+      const content = readFileSync(dest, 'utf-8').trim().split('\n');
+      expect(content[0]).toBe('id,subject,from');
+      // At least the 5 seeded messages — integration envs may carry extras
+      expect(content.length - 1).toBeGreaterThanOrEqual(5);
+    });
+
+    it('exports NDJSON with one JSON object per line', async () => {
+      const subject = `ndjson-export-${Date.now()}`;
+      await seedEmails(5, { subject });
+      await waitForDelivery();
+
+      const { items } = await services.imapService.searchForExport(null, TEST_ACCOUNT_NAME, '', {
+        mailbox: 'INBOX',
+        subject,
+        maxRows: 100,
+      });
+
+      const dest = join(workDir, 'export.ndjson');
+      await writeExport({ format: 'ndjson', items, columns: [], destination: dest });
+
+      const content = readFileSync(dest, 'utf-8').trim().split('\n');
+      expect(content.length).toBe(items.length);
+      const first = JSON.parse(content[0]);
+      expect(typeof first.id).toBe('string');
+      expect(typeof first.subject).toBe('string');
+    });
+
+    it('sets truncated=true when the underlying match set exceeds maxRows', async () => {
+      const subject = `truncate-${Date.now()}`;
+      await seedEmails(6, { subject });
+      await waitForDelivery();
+
+      const { items, truncated } = await services.imapService.searchForExport(
+        null,
+        TEST_ACCOUNT_NAME,
+        '',
+        { mailbox: 'INBOX', subject, maxRows: 3 },
+      );
+
+      expect(items.length).toBeLessThanOrEqual(3);
+      expect(truncated).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // save_all_attachments_from_search (service: saveAllAttachmentsFromSearch)
+  // ---------------------------------------------------------------------------
+  describe('saveAllAttachmentsFromSearch', () => {
+    it('downloads attachments from matching emails, skips emails without attachments', async () => {
+      const subject = `batch-att-${Date.now()}`;
+      // 2 with PDFs, 1 plain (no attachment)
+      await seedEmailWithAttachment('doc1.pdf', PDF_MAGIC.toString('base64'), { subject });
+      await seedEmailWithAttachment('doc2.pdf', PDF_MAGIC.toString('base64'), { subject });
+      await seedEmail({ subject, text: 'plain body with no attachment' });
+      await waitForDelivery();
+
+      const folder = join(workDir, 'sweep');
+
+      const result = await services.imapService.saveAllAttachmentsFromSearch({
+        accountNames: null,
+        accountName: TEST_ACCOUNT_NAME,
+        query: '',
+        searchOptions: { mailbox: 'INBOX', subject },
+        maxEmails: 100,
+        destinationFolder: folder,
+        organizeBy: 'flat',
+      });
+
+      expect(result.folder).toBe(folder);
+      expect(result.files_saved).toBeGreaterThanOrEqual(2);
+      expect(result.skipped).toBeGreaterThanOrEqual(1);
+      expect(result.errors).toEqual([]);
+      expect(result.total_size).toBeGreaterThan(0);
+    });
+
+    it('organizes by date → files land in YYYY-MM/ subfolders', async () => {
+      const { readdirSync } = await import('node:fs');
+      const subject = `batch-date-${Date.now()}`;
+      await seedEmailWithAttachment('dated.pdf', PDF_MAGIC.toString('base64'), { subject });
+      await waitForDelivery();
+
+      const folder = join(workDir, 'by-date');
+
+      const result = await services.imapService.saveAllAttachmentsFromSearch({
+        accountNames: null,
+        accountName: TEST_ACCOUNT_NAME,
+        query: '',
+        searchOptions: { mailbox: 'INBOX', subject },
+        maxEmails: 10,
+        destinationFolder: folder,
+        organizeBy: 'date',
+      });
+
+      expect(result.files_saved).toBeGreaterThanOrEqual(1);
+      // Folder should contain at least one `YYYY-MM` subfolder
+      const entries = readdirSync(folder);
+      expect(entries.length).toBeGreaterThanOrEqual(1);
+      expect(entries.some((e) => /^\d{4}-\d{2}$/.test(e))).toBe(true);
+    });
+  });
+});

--- a/src/__integration__/helpers/index.ts
+++ b/src/__integration__/helpers/index.ts
@@ -11,6 +11,7 @@ export {
   seedEmail,
   seedEmails,
   seedEmailWithAttachment,
+  seedEmailWithInlineAttachmentNoCid,
   seedThread,
   waitForDelivery,
 } from './seed.js';

--- a/src/__integration__/helpers/seed.ts
+++ b/src/__integration__/helpers/seed.ts
@@ -107,3 +107,25 @@ export async function seedEmailWithAttachment(
 export async function waitForDelivery(ms = 500): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Seed an HTML email that contains an inline image without a Content-ID.
+ * This is the trigger case for the has_attachment regression: extractAttachmentMeta
+ * surfaces inline parts without CIDs; the old hasAttachments() boolean did not.
+ */
+export async function seedEmailWithInlineAttachmentNoCid(options: SeedEmailOptions = {}) {
+  return seedEmail({
+    ...options,
+    subject: options.subject ?? 'Email with inline image no cid',
+    html: '<p>Check out this image</p>',
+    attachments: [
+      {
+        filename: 'banner.gif',
+        content: Buffer.from('GIF89a'),
+        contentType: 'image/gif',
+        contentDisposition: 'inline',
+        // Intentionally no cid field — exercises the no-Content-ID inline path
+      },
+    ],
+  });
+}

--- a/src/__integration__/search-filters.integration.test.ts
+++ b/src/__integration__/search-filters.integration.test.ts
@@ -4,6 +4,7 @@ import {
   createTestServices,
   seedEmail,
   seedEmailWithAttachment,
+  seedEmailWithInlineAttachmentNoCid,
   TEST_ACCOUNT_NAME,
   waitForDelivery,
 } from './helpers/index.js';
@@ -199,6 +200,43 @@ describe('Power Search filters (integration)', () => {
       // sender / year should not be populated when not requested.
       expect(result.facets?.sender).toBeUndefined();
       expect(result.facets?.year).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase H — has_attachment regression (inline image without Content-ID)
+  // -------------------------------------------------------------------------
+
+  describe('has_attachment regression — inline image no Content-ID', () => {
+    let inlineNoCidSubject: string;
+
+    beforeAll(async () => {
+      inlineNoCidSubject = `Inline no-cid regression ${Date.now()}`;
+      await seedEmailWithInlineAttachmentNoCid({ subject: inlineNoCidSubject });
+      await waitForDelivery();
+    });
+
+    it('search_emails(has_attachment=true) returns the inline-no-cid email', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        hasAttachment: true,
+        pageSize: 100,
+      });
+      const found = result.items.find((e) => e.subject === inlineNoCidSubject);
+      expect(found).toBeDefined();
+      // The attachments array must also be populated (semantic alignment).
+      expect((found?.attachments ?? []).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('the seeded email carries banner.gif in its attachments metadata', async () => {
+      // Verify extractAttachmentMeta surfaces the inline-no-cid image.
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        subject: inlineNoCidSubject,
+        pageSize: 10,
+      });
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      const email = result.items[0];
+      expect(email.hasAttachments).toBe(true);
+      expect((email.attachments ?? []).some((a) => /banner\.gif/.test(a.filename))).toBe(true);
     });
   });
 });

--- a/src/__integration__/search-filters.integration.test.ts
+++ b/src/__integration__/search-filters.integration.test.ts
@@ -1,0 +1,114 @@
+import type { TestServices } from './helpers/index.js';
+import {
+  buildTestAccount,
+  createTestServices,
+  seedEmail,
+  TEST_ACCOUNT_NAME,
+  waitForDelivery,
+} from './helpers/index.js';
+
+describe('Power Search filters (integration)', () => {
+  let services: TestServices;
+
+  beforeAll(async () => {
+    services = createTestServices(buildTestAccount());
+
+    // Seed a varied set of emails so the filters actually narrow.
+    await seedEmail({ from: 'alice@localhost', subject: 'Quarterly Report' });
+    await seedEmail({ from: 'alice@localhost', subject: 'Pines Rd invoice' });
+    await seedEmail({ from: 'bob@localhost', subject: 'Vacation plans' });
+    await seedEmail({ from: 'bob@localhost', subject: 'Lunch tomorrow' });
+    await seedEmail({ from: 'alice@localhost', subject: 'Follow-up on report' });
+    await waitForDelivery();
+  });
+
+  afterAll(async () => {
+    await services.connections.closeAll();
+  });
+
+  describe('date filters', () => {
+    it('since "today" returns same-day messages (all of them since we just seeded)', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        since: 'today',
+      });
+      expect(result.total).toBeGreaterThanOrEqual(5);
+    });
+
+    it('since a future date narrows to zero', async () => {
+      const future = new Date();
+      future.setUTCFullYear(future.getUTCFullYear() + 1);
+      const iso = future.toISOString().slice(0, 10); // YYYY-MM-DD
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        since: iso,
+      });
+      expect(result.total).toBe(0);
+    });
+
+    it('before "today" excludes just-seeded emails (same-day)', async () => {
+      // NOTE: IMAP BEFORE is strict — excludes current day. GreenMail may index
+      // messages against its own clock. If all messages were delivered today,
+      // before:today returns 0. Tolerate slight drift.
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        before: 'today',
+      });
+      expect(result.total).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe('from filter', () => {
+    it('returns only messages from alice when from="alice"', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        from: 'alice@localhost',
+      });
+      expect(result.items.length).toBeGreaterThanOrEqual(3);
+      for (const email of result.items) {
+        expect(email.from.address).toContain('alice');
+      }
+    });
+  });
+
+  describe('subject filter', () => {
+    it('narrows by subject substring', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        subject: 'Pines Rd',
+      });
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      expect(result.items[0].subject).toMatch(/Pines Rd/);
+    });
+  });
+
+  describe('combined filters', () => {
+    it('from + subject narrows further than either alone', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        from: 'alice@localhost',
+        subject: 'report',
+      });
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      for (const email of result.items) {
+        expect(email.from.address).toContain('alice');
+        expect(email.subject.toLowerCase()).toContain('report');
+      }
+    });
+  });
+
+  describe('seen filter', () => {
+    it('seen:false returns unread-only results', async () => {
+      // All freshly seeded emails start unseen.
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        seen: false,
+      });
+      expect(result.items.length).toBeGreaterThanOrEqual(5);
+      for (const email of result.items) {
+        expect(email.seen).toBe(false);
+      }
+    });
+  });
+
+  describe('gmail_raw on non-Gmail account', () => {
+    it('throws a clear error when used against GreenMail', async () => {
+      await expect(
+        services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', { gmailRaw: 'from:foo' }),
+      ).rejects.toThrow(/only valid on Gmail accounts/);
+    });
+  });
+});

--- a/src/__integration__/search-filters.integration.test.ts
+++ b/src/__integration__/search-filters.integration.test.ts
@@ -3,6 +3,7 @@ import {
   buildTestAccount,
   createTestServices,
   seedEmail,
+  seedEmailWithAttachment,
   TEST_ACCOUNT_NAME,
   waitForDelivery,
 } from './helpers/index.js';
@@ -109,6 +110,95 @@ describe('Power Search filters (integration)', () => {
       await expect(
         services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', { gmailRaw: 'from:foo' }),
       ).rejects.toThrow(/only valid on Gmail accounts/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase E — attachment filename + mimetype filters
+  // -------------------------------------------------------------------------
+
+  describe('attachment filters (Phase E)', () => {
+    beforeAll(async () => {
+      // Seed a PDF-style attachment whose filename contains "lease".
+      await seedEmailWithAttachment('signed_lease_v7.pdf', 'fake pdf bytes', {
+        subject: 'Pines Rd lease with attachment',
+      });
+      // And an unrelated text attachment so filename/mimetype filters have to discriminate.
+      await seedEmailWithAttachment('notes.txt', 'just some notes', {
+        subject: 'Meeting notes',
+      });
+      await waitForDelivery();
+    });
+
+    it('attachmentFilename="lease" narrows to the seeded PDF', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        attachmentFilename: 'lease',
+        pageSize: 50,
+      });
+      // Expect at least one hit whose attachments include a filename containing "lease".
+      expect(result.items.length).toBeGreaterThanOrEqual(1);
+      for (const email of result.items) {
+        expect((email.attachments ?? []).some((a) => /lease/i.test(a.filename))).toBe(true);
+      }
+    });
+
+    it('attachmentMimetype="text/plain" returns emails carrying a text attachment', async () => {
+      // GreenMail delivers attachments via nodemailer which labels .txt as text/plain.
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        attachmentMimetype: 'text/plain',
+        pageSize: 50,
+      });
+      // Must surface the notes.txt email (filename includes "notes").
+      expect(
+        result.items.some((e) => (e.attachments ?? []).some((a) => /notes\.txt/.test(a.filename))),
+      ).toBe(true);
+      for (const email of result.items) {
+        expect((email.attachments ?? []).some((a) => /^text\/plain/i.test(a.mimeType))).toBe(true);
+      }
+    });
+
+    it('invalid attachmentMimetype regex raises a friendly error', async () => {
+      await expect(
+        services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+          attachmentMimetype: '[',
+          pageSize: 10,
+        }),
+      ).rejects.toThrow(/Invalid attachment_mimetype pattern/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase G — faceted counts
+  // -------------------------------------------------------------------------
+
+  describe('faceted counts (Phase G)', () => {
+    it('facets: ["sender","year"] returns bucketed counts from the current seed', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        facets: ['sender', 'year'],
+        pageSize: 10,
+      });
+      expect(result.facets).toBeDefined();
+      expect(result.facets?.sender).toBeDefined();
+      expect(result.facets?.year).toBeDefined();
+
+      // Sum of sender counts should equal the full (capped) match set.
+      const senderTotal = Object.values(result.facets?.sender ?? {}).reduce((a, b) => a + b, 0);
+      expect(senderTotal).toBe(result.total);
+
+      // We seeded at least one alice@localhost — must appear in sender bucket.
+      const senders = Object.keys(result.facets?.sender ?? {});
+      expect(senders.some((s) => s.includes('alice'))).toBe(true);
+    });
+
+    it('facets: ["mailbox"] returns { INBOX: total } without an envelope scan', async () => {
+      const result = await services.imapService.searchEmails(TEST_ACCOUNT_NAME, '', {
+        facets: ['mailbox'],
+        pageSize: 5,
+      });
+      expect(result.facets?.mailbox).toEqual({ INBOX: result.total });
+      // sender / year should not be populated when not requested.
+      expect(result.facets?.sender).toBeUndefined();
+      expect(result.facets?.year).toBeUndefined();
     });
   });
 });

--- a/src/cli/account-commands.ts
+++ b/src/cli/account-commands.ts
@@ -525,6 +525,7 @@ async function addAccount(): Promise<void> {
           },
         },
         accounts: [newAccount],
+        searches: [],
       };
 
   AppConfigFileSchema.parse(config);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,8 +8,14 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
-import type { AccountConfig, AppConfig, HookRule, OAuth2Config } from '../types/index.js';
-import type { RawAccountConfig, RawAppConfig } from './schema.js';
+import type {
+  AccountConfig,
+  AppConfig,
+  HookRule,
+  OAuth2Config,
+  SearchPreset,
+} from '../types/index.js';
+import type { RawAccountConfig, RawAppConfig, RawSearchPreset } from './schema.js';
 import { AppConfigFileSchema } from './schema.js';
 import { CONFIG_FILE, xdg } from './xdg.js';
 
@@ -119,6 +125,7 @@ function loadFromEnv(): RawAppConfig | null {
         },
       },
     ],
+    searches: [],
   };
 }
 
@@ -205,6 +212,44 @@ function normalizeHookRule(raw: {
   };
 }
 
+function normalizeSearchPreset(raw: RawSearchPreset): SearchPreset {
+  return {
+    name: raw.name,
+    description: raw.description,
+    account: raw.account,
+    accounts: raw.accounts,
+    mailbox: raw.mailbox,
+    query: raw.query,
+    to: raw.to,
+    from: raw.from,
+    subject: raw.subject,
+    cc: raw.cc,
+    bcc: raw.bcc,
+    text: raw.text,
+    body: raw.body,
+    since: raw.since,
+    before: raw.before,
+    on: raw.on,
+    sentSince: raw.sent_since,
+    sentBefore: raw.sent_before,
+    seen: raw.seen,
+    flagged: raw.flagged,
+    answered: raw.answered,
+    draft: raw.draft,
+    deleted: raw.deleted,
+    keyword: raw.keyword,
+    notKeyword: raw.not_keyword,
+    header: raw.header,
+    largerThan: raw.larger_than,
+    smallerThan: raw.smaller_than,
+    hasAttachment: raw.has_attachment,
+    attachmentFilename: raw.attachment_filename,
+    attachmentMimetype: raw.attachment_mimetype,
+    facets: raw.facets,
+    gmailRaw: raw.gmail_raw,
+  };
+}
+
 function normalizeConfig(raw: RawAppConfig): AppConfig {
   return {
     settings: {
@@ -238,6 +283,7 @@ function normalizeConfig(raw: RawAppConfig): AppConfig {
       },
     },
     accounts: raw.accounts.map(normalizeAccount),
+    searches: (raw.searches ?? []).map(normalizeSearchPreset),
   };
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -179,6 +179,9 @@ function normalizeAccount(raw: RawAccountConfig): AccountConfig {
         maxMessages: raw.smtp.pool.max_messages,
       },
     },
+    sentFolder: raw.sent_folder,
+    saveToSent: raw.save_to_sent,
+    gmailAutoSave: raw.gmail_auto_save,
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -52,6 +52,9 @@ export const AccountConfigSchema = z
     oauth2: OAuth2ConfigSchema.optional(),
     imap: ImapConfigSchema,
     smtp: SmtpConfigSchema,
+    sent_folder: z.string().optional(),
+    save_to_sent: z.boolean().optional(),
+    gmail_auto_save: z.boolean().optional(),
   })
   .refine((data) => data.password ?? data.oauth2, {
     message: 'Either password or oauth2 config is required',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -144,6 +144,51 @@ export const SettingsSchema = z.object({
   }),
 });
 
+// ---------------------------------------------------------------------------
+// Saved-search presets — `[[searches]]` in config.toml
+// ---------------------------------------------------------------------------
+
+export const SearchPresetSchema = z
+  .object({
+    name: z.string().min(1, 'Search preset name is required'),
+    description: z.string().optional(),
+    account: z.string().optional(),
+    accounts: z.array(z.string()).optional(),
+    mailbox: z.string().optional(),
+    // SearchParams fields — snake_case to mirror TOML style.
+    query: z.string().optional(),
+    to: z.string().optional(),
+    from: z.string().optional(),
+    subject: z.string().optional(),
+    cc: z.string().optional(),
+    bcc: z.string().optional(),
+    text: z.string().optional(),
+    body: z.string().optional(),
+    since: z.string().optional(),
+    before: z.string().optional(),
+    on: z.string().optional(),
+    sent_since: z.string().optional(),
+    sent_before: z.string().optional(),
+    seen: z.boolean().optional(),
+    flagged: z.boolean().optional(),
+    answered: z.boolean().optional(),
+    draft: z.boolean().optional(),
+    deleted: z.boolean().optional(),
+    keyword: z.union([z.string(), z.array(z.string())]).optional(),
+    not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+    header: z.record(z.string(), z.string()).optional(),
+    larger_than: z.number().optional(),
+    smaller_than: z.number().optional(),
+    has_attachment: z.boolean().optional(),
+    attachment_filename: z.string().optional(),
+    attachment_mimetype: z.string().optional(),
+    facets: z.array(z.enum(['sender', 'year', 'mailbox'])).optional(),
+    gmail_raw: z.string().optional(),
+  })
+  .refine((p) => !(p.account && p.accounts && p.accounts.length > 0), {
+    message: "Use 'account' OR 'accounts', not both",
+  });
+
 export const AppConfigFileSchema = z.object({
   settings: SettingsSchema.default({
     rate_limit: 10,
@@ -174,7 +219,9 @@ export const AppConfigFileSchema = z.object({
     },
   }),
   accounts: z.array(AccountConfigSchema).min(1, 'At least one account is required'),
+  searches: z.array(SearchPresetSchema).default([]),
 });
 
 export type RawAccountConfig = z.infer<typeof AccountConfigSchema>;
 export type RawAppConfig = z.infer<typeof AppConfigFileSchema>;
+export type RawSearchPreset = z.infer<typeof SearchPresetSchema>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import LocalCalendarService from './services/local-calendar.service.js';
 import OAuthService from './services/oauth.service.js';
 import RemindersService from './services/reminders.service.js';
 import SchedulerService from './services/scheduler.service.js';
+import { SearchPresetRegistry } from './services/search-presets.js';
 import SmtpService from './services/smtp.service.js';
 import TemplateService from './services/template.service.js';
 import WatcherService from './services/watcher.service.js';
@@ -85,6 +86,7 @@ async function runServer(): Promise<void> {
   const schedulerService = new SchedulerService(smtpService, imapService);
   const watcherService = new WatcherService(config.settings.watcher, config.accounts);
   const hooksService = new HooksService(config.settings.hooks, imapService);
+  const searchPresetRegistry = new SearchPresetRegistry(config.searches);
 
   const server = createServer();
   bindServer(server);
@@ -102,6 +104,7 @@ async function runServer(): Promise<void> {
     schedulerService,
     watcherService,
     hooksService,
+    searchPresetRegistry,
   );
   registerAllResources(server, connections, imapService, templateService, schedulerService);
   registerAllPrompts(server);

--- a/src/services/attachments.test.ts
+++ b/src/services/attachments.test.ts
@@ -1,0 +1,152 @@
+import { extractAttachmentMeta } from './imap.service.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — shapes mirror imapflow's parsed bodyStructure (type as
+// "maintype/subtype", childNodes array, disposition / dispositionParameters).
+// ---------------------------------------------------------------------------
+
+const multipartMixedWithPdf = {
+  type: 'multipart/mixed',
+  childNodes: [
+    {
+      type: 'text/plain',
+      size: 100,
+      parameters: { charset: 'utf-8' },
+    },
+    {
+      type: 'application/pdf',
+      size: 204800,
+      disposition: 'attachment',
+      dispositionParameters: { filename: 'lease_agreement_v7.pdf' },
+    },
+  ],
+};
+
+const multipartAlternativeNoAttach = {
+  type: 'multipart/alternative',
+  childNodes: [
+    { type: 'text/plain', size: 100 },
+    { type: 'text/html', size: 300 },
+  ],
+};
+
+const multipartMixedWithInlineImage = {
+  type: 'multipart/mixed',
+  childNodes: [
+    {
+      type: 'multipart/alternative',
+      childNodes: [
+        { type: 'text/plain', size: 100 },
+        {
+          type: 'multipart/related',
+          childNodes: [
+            { type: 'text/html', size: 400 },
+            {
+              type: 'image/png',
+              size: 8000,
+              id: '<logo@example.com>',
+              disposition: 'inline',
+              dispositionParameters: { filename: 'logo.png' },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const nestedPdfTwoLevels = {
+  type: 'multipart/mixed',
+  childNodes: [
+    {
+      type: 'multipart/alternative',
+      childNodes: [
+        {
+          type: 'multipart/mixed',
+          childNodes: [
+            { type: 'text/plain', size: 100 },
+            {
+              type: 'application/pdf',
+              size: 102400,
+              disposition: 'attachment',
+              dispositionParameters: { filename: 'signed_addendum.pdf' },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const pdfWithNameParamOnly = {
+  // Common mailer quirk — filename only on Content-Type parameters, no
+  // Content-Disposition header at all.
+  type: 'multipart/mixed',
+  childNodes: [
+    { type: 'text/plain', size: 100 },
+    {
+      type: 'application/pdf',
+      size: 4096,
+      parameters: { name: 'invoice.pdf' },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('extractAttachmentMeta', () => {
+  it('returns [] for undefined bodyStructure', () => {
+    expect(extractAttachmentMeta(undefined)).toEqual([]);
+  });
+
+  it('returns [] when body has no attachments (text/plain + text/html alternative)', () => {
+    expect(extractAttachmentMeta(multipartAlternativeNoAttach)).toEqual([]);
+  });
+
+  it('extracts a top-level PDF attachment with filename/mimeType/size', () => {
+    const result = extractAttachmentMeta(multipartMixedWithPdf);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      filename: 'lease_agreement_v7.pdf',
+      mimeType: 'application/pdf',
+      size: 204800,
+    });
+  });
+
+  it('skips inline images (disposition=inline + content-id)', () => {
+    const result = extractAttachmentMeta(multipartMixedWithInlineImage);
+    expect(result).toEqual([]);
+  });
+
+  it('finds a PDF buried two multipart levels deep', () => {
+    const result = extractAttachmentMeta(nestedPdfTwoLevels);
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe('signed_addendum.pdf');
+    expect(result[0].mimeType).toBe('application/pdf');
+    expect(result[0].size).toBe(102400);
+  });
+
+  it('detects PDFs advertised via Content-Type name= (no Content-Disposition)', () => {
+    const result = extractAttachmentMeta(pdfWithNameParamOnly);
+    expect(result).toHaveLength(1);
+    expect(result[0].filename).toBe('invoice.pdf');
+    expect(result[0].mimeType).toBe('application/pdf');
+  });
+
+  it('does not treat a plain text part with a name= param as an attachment', () => {
+    // Avoid false positives for legitimate inline text bodies.
+    const struct = {
+      type: 'multipart/mixed',
+      childNodes: [{ type: 'text/plain', size: 100, parameters: { name: 'body.txt' } }],
+    };
+    expect(extractAttachmentMeta(struct)).toEqual([]);
+  });
+
+  it('handles malformed input gracefully', () => {
+    expect(extractAttachmentMeta(null)).toEqual([]);
+    expect(extractAttachmentMeta('not an object')).toEqual([]);
+    expect(extractAttachmentMeta({})).toEqual([]);
+  });
+});

--- a/src/services/attachments.test.ts
+++ b/src/services/attachments.test.ts
@@ -144,6 +144,33 @@ describe('extractAttachmentMeta', () => {
     expect(extractAttachmentMeta(struct)).toEqual([]);
   });
 
+  // Regression: PR 2 regression — inline image WITHOUT Content-ID must be
+  // treated as an attachment (not skipped). The has_attachment boolean must
+  // agree with the attachments array.
+  it('inline image with NO content-id is treated as an attachment (regression for has_attachment filter)', () => {
+    const inlineNoCid = {
+      type: 'multipart/related',
+      childNodes: [
+        { type: 'text/html', size: 200 },
+        {
+          type: 'image/gif',
+          size: 3000,
+          disposition: 'inline',
+          // Intentionally no 'id' field — no Content-ID header
+          dispositionParameters: { filename: 'banner.gif' },
+        },
+      ],
+    };
+    const attachments = extractAttachmentMeta(inlineNoCid);
+    // The inline image has no CID, so it must surface as an attachment.
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].filename).toBe('banner.gif');
+    expect(attachments[0].mimeType).toBe('image/gif');
+    // Semantic alignment: hasAttachments boolean must agree.
+    const hasAtt = attachments.length > 0;
+    expect(hasAtt).toBe(true);
+  });
+
   it('handles malformed input gracefully', () => {
     expect(extractAttachmentMeta(null)).toEqual([]);
     expect(extractAttachmentMeta('not an object')).toEqual([]);

--- a/src/services/attachments.test.ts
+++ b/src/services/attachments.test.ts
@@ -1,3 +1,8 @@
+/* eslint-disable n/no-sync -- tests use sync fs helpers for setup/teardown */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveUniquePath, sanitizeFilename } from './file-paths.js';
 import { extractAttachmentMeta } from './imap.service.js';
 
 // ---------------------------------------------------------------------------
@@ -175,5 +180,104 @@ describe('extractAttachmentMeta', () => {
     expect(extractAttachmentMeta(null)).toEqual([]);
     expect(extractAttachmentMeta('not an object')).toEqual([]);
     expect(extractAttachmentMeta({})).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFilename — strips path separators + reserved characters (PR 4)
+// ---------------------------------------------------------------------------
+
+describe('sanitizeFilename', () => {
+  it('strips forward-slashes and backslashes', () => {
+    expect(sanitizeFilename('some/path/lease.pdf')).toBe('some_path_lease.pdf');
+    expect(sanitizeFilename('some\\path\\lease.pdf')).toBe('some_path_lease.pdf');
+  });
+
+  it('replaces Windows-reserved and shell-special chars with underscore', () => {
+    expect(sanitizeFilename('foo<bar>.pdf')).toBe('foo_bar_.pdf');
+    expect(sanitizeFilename('a"b|c?d*e.pdf')).toBe('a_b_c_d_e.pdf');
+  });
+
+  it('collapses consecutive underscores from multi-char replacements', () => {
+    expect(sanitizeFilename('a////b.pdf')).toBe('a_b.pdf');
+  });
+
+  it('strips leading dots to prevent hidden-file surprises', () => {
+    expect(sanitizeFilename('...hidden.txt')).toBe('hidden.txt');
+  });
+
+  it('strips trailing dots and whitespace', () => {
+    expect(sanitizeFilename('lease.pdf...  ')).toBe('lease.pdf');
+  });
+
+  it("neutralizes '..' traversal — reduces to 'unnamed' after strip passes", () => {
+    expect(sanitizeFilename('..')).toBe('unnamed');
+  });
+
+  it('returns "unnamed" for empty / whitespace-only / dot-only inputs', () => {
+    expect(sanitizeFilename('')).toBe('unnamed');
+    expect(sanitizeFilename('   ')).toBe('unnamed');
+    expect(sanitizeFilename('.')).toBe('unnamed');
+  });
+
+  it('preserves a normal filename untouched', () => {
+    expect(sanitizeFilename('quarterly_report_v7.pdf')).toBe('quarterly_report_v7.pdf');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveUniquePath — collision auto-suffix (PR 4)
+// ---------------------------------------------------------------------------
+
+describe('resolveUniquePath', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'pr4-collide-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns the desired path unchanged when nothing exists there', async () => {
+    const p = join(tmp, 'lease.pdf');
+    await expect(resolveUniquePath(p, false)).resolves.toBe(p);
+  });
+
+  it('returns the desired path unchanged when overwrite=true (even if the file exists)', async () => {
+    const p = join(tmp, 'lease.pdf');
+    writeFileSync(p, 'old');
+    await expect(resolveUniquePath(p, true)).resolves.toBe(p);
+  });
+
+  it('auto-suffixes lease.pdf -> lease-1.pdf when the target exists', async () => {
+    const p = join(tmp, 'lease.pdf');
+    writeFileSync(p, 'original');
+    await expect(resolveUniquePath(p, false)).resolves.toBe(join(tmp, 'lease-1.pdf'));
+  });
+
+  it('increments the suffix until a free slot is found', async () => {
+    writeFileSync(join(tmp, 'lease.pdf'), 'x');
+    writeFileSync(join(tmp, 'lease-1.pdf'), 'x');
+    writeFileSync(join(tmp, 'lease-2.pdf'), 'x');
+    await expect(resolveUniquePath(join(tmp, 'lease.pdf'), false)).resolves.toBe(
+      join(tmp, 'lease-3.pdf'),
+    );
+  });
+
+  it('keeps the original extension intact across suffixing', async () => {
+    writeFileSync(join(tmp, 'archive.tar.gz'), 'x');
+    // basename(filename, '.gz') -> 'archive.tar' so suffix appends before .gz
+    await expect(resolveUniquePath(join(tmp, 'archive.tar.gz'), false)).resolves.toBe(
+      join(tmp, 'archive.tar-1.gz'),
+    );
+  });
+
+  it('suffixes files without an extension', async () => {
+    writeFileSync(join(tmp, 'README'), 'x');
+    await expect(resolveUniquePath(join(tmp, 'README'), false)).resolves.toBe(
+      join(tmp, 'README-1'),
+    );
   });
 });

--- a/src/services/csv.test.ts
+++ b/src/services/csv.test.ts
@@ -1,0 +1,68 @@
+import { escapeCsvField, toCsvRow } from './csv.js';
+
+describe('escapeCsvField', () => {
+  it('returns empty string for null / undefined', () => {
+    expect(escapeCsvField(null)).toBe('');
+    expect(escapeCsvField(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(escapeCsvField('')).toBe('');
+  });
+
+  it('passes through plain values without quoting', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+    expect(escapeCsvField('lease.pdf')).toBe('lease.pdf');
+    expect(escapeCsvField(42)).toBe('42');
+    expect(escapeCsvField(true)).toBe('true');
+  });
+
+  it('quotes fields containing commas', () => {
+    expect(escapeCsvField('Smith, John')).toBe('"Smith, John"');
+  });
+
+  it('quotes fields containing embedded double-quotes and doubles them', () => {
+    expect(escapeCsvField('She said "hi"')).toBe('"She said ""hi"""');
+  });
+
+  it('quotes fields containing newlines (LF and CR)', () => {
+    expect(escapeCsvField('line1\nline2')).toBe('"line1\nline2"');
+    expect(escapeCsvField('line1\rline2')).toBe('"line1\rline2"');
+    expect(escapeCsvField('line1\r\nline2')).toBe('"line1\r\nline2"');
+  });
+
+  it('handles a field with every edge case simultaneously', () => {
+    const evil = 'He said "hi,there"\nline2';
+    expect(escapeCsvField(evil)).toBe('"He said ""hi,there""\nline2"');
+  });
+});
+
+describe('toCsvRow', () => {
+  it('joins fields with commas', () => {
+    expect(toCsvRow(['a', 'b', 'c'])).toBe('a,b,c');
+  });
+
+  it('escapes each field independently', () => {
+    expect(toCsvRow(['plain', 'has,comma', 'has"quote'])).toBe('plain,"has,comma","has""quote"');
+  });
+
+  it('serializes a row containing every edge case (single row with all escapes)', () => {
+    const row = [
+      '42', // id — plain
+      'alice', // account
+      '2024-01-15', // date
+      'Smith, John <john@x.com>', // from — has comma
+      'Subject with "quotes" and\nnewlines', // subject — has quote + newline
+      '', // labels — empty
+      'file,with,commas.pdf', // attachments
+    ];
+    const line = toCsvRow(row);
+    expect(line).toBe(
+      '42,alice,2024-01-15,"Smith, John <john@x.com>","Subject with ""quotes"" and\nnewlines",,"file,with,commas.pdf"',
+    );
+  });
+
+  it('produces an empty CSV line for an empty row array', () => {
+    expect(toCsvRow([])).toBe('');
+  });
+});

--- a/src/services/csv.ts
+++ b/src/services/csv.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimal CSV writer helpers — RFC 4180 conformant field escaping.
+ *
+ * We avoid pulling in a dependency for a ~20 LOC helper. The only tricky rule
+ * is the quoting: fields containing `"`, `,`, `\r`, or `\n` must be wrapped in
+ * double-quotes, with any embedded `"` doubled up.
+ */
+
+/**
+ * Escape a single CSV field per RFC 4180.
+ *
+ * - Stringifies non-string values with `String(value)`.
+ * - `null` / `undefined` become empty strings (no quotes, no literal "null").
+ * - Wraps in double-quotes only when the value contains `"`, `,`, `\r`, or `\n`.
+ * - Doubles up embedded `"` inside quoted fields.
+ */
+export function escapeCsvField(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = typeof value === 'string' ? value : String(value);
+  if (str === '') return '';
+  const needsQuoting = /["\n\r,]/.test(str);
+  if (!needsQuoting) return str;
+  return `"${str.replace(/"/g, '""')}"`;
+}
+
+/**
+ * Serialize one row of fields to a single CSV line (no trailing newline).
+ * Each field is escaped with `escapeCsvField`.
+ */
+export function toCsvRow(fields: unknown[]): string {
+  return fields.map(escapeCsvField).join(',');
+}

--- a/src/services/file-paths.ts
+++ b/src/services/file-paths.ts
@@ -1,0 +1,107 @@
+/**
+ * Filesystem-path helpers for the direct-to-disk export / save tools.
+ *
+ * - `sanitizeFilename` — strip path separators and reserved characters so we
+ *   never let an attacker's filename break out of the destination directory.
+ * - `assertSafeDestination` — guard-rail that rejects any destination outside
+ *   the user's home directory (or `/tmp`). Normalizes `..` traversal.
+ * - `resolveUniquePath` — auto-suffix `name.ext` → `name-1.ext`, `name-2.ext`
+ *   when the caller doesn't want to overwrite.
+ */
+
+import { access } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { basename, dirname, extname, isAbsolute, join, resolve } from 'node:path';
+
+/** Async existence check — uses `fs.access`; throws become "does not exist". */
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Replace anything that could make a filename unsafe with `_`. Also strips
+ * leading/trailing dots so we don't produce `..` or hidden-file surprises.
+ *
+ * Safe on all three major platforms (macOS, Linux, Windows).
+ */
+export function sanitizeFilename(name: string): string {
+  // Strip any directory separators first — we only want the leaf.
+  const leaf = name.replace(/[\\/]/g, '_');
+  // Replace Windows-reserved and other problematic chars with `_`.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — reject control chars in filenames
+  const replaced = leaf.replace(/[<>:"|?*\x00-\x1F]/g, '_'); // eslint-disable-line no-control-regex
+  // Collapse consecutive underscores introduced by the replace pass.
+  const collapsed = replaced.replace(/_+/g, '_');
+  // Trim leading dots so we don't produce `.hidden` files accidentally, and
+  // trim trailing whitespace or dots (Windows rejects trailing dots anyway).
+  const trimmed = collapsed.replace(/^\.+/, '').replace(/[.\s]+$/, '');
+  return trimmed.length > 0 ? trimmed : 'unnamed';
+}
+
+/**
+ * Validate that a target path lies under the user's home directory OR under
+ * the OS tmp dir. Throws an Error describing the violation otherwise.
+ *
+ * The checks use `path.resolve` to canonicalize, so `..` traversal
+ * (`~/Downloads/../../etc/passwd`) is caught. `startsWith` is compared with
+ * the platform separator appended so `/tmp-evil/` isn't treated as inside
+ * `/tmp`.
+ */
+export function assertSafeDestination(absolutePath: string): void {
+  if (!isAbsolute(absolutePath)) {
+    throw new Error(`Destination must be an absolute path, got: ${absolutePath}`);
+  }
+
+  const resolved = resolve(absolutePath);
+
+  // Reject any path that contains `..` as a literal segment after resolve —
+  // resolve() collapses most cases, but catching the raw `..` in the input
+  // gives a clearer error than the home-check failing further down.
+  if (absolutePath.split(/[\\/]/).includes('..')) {
+    throw new Error(`Destination path must not contain ".." traversal segments: ${absolutePath}`);
+  }
+
+  const home = resolve(homedir());
+  const tmp = resolve(tmpdir());
+
+  // Append path separator so `/tmp-evil` isn't accepted as inside `/tmp`. The
+  // exact equality case (path === home / tmp) is also valid.
+  const underHome = resolved === home || resolved.startsWith(`${home}/`);
+  const underTmp = resolved === tmp || resolved.startsWith(`${tmp}/`);
+
+  if (!underHome && !underTmp) {
+    throw new Error(
+      `Destination "${resolved}" is outside the user's home directory and tmp dir — refusing to write.`,
+    );
+  }
+}
+
+/**
+ * Given a desired destination path, return a unique path that does not
+ * collide with an existing file. If `filename.ext` already exists, try
+ * `filename-1.ext`, `filename-2.ext`, ... up to 9999.
+ *
+ * When `overwrite=true` this simply returns the input unchanged.
+ */
+export async function resolveUniquePath(desiredPath: string, overwrite: boolean): Promise<string> {
+  if (overwrite) return desiredPath;
+  if (!(await pathExists(desiredPath))) return desiredPath;
+
+  const dir = dirname(desiredPath);
+  const ext = extname(desiredPath);
+  const base = basename(desiredPath, ext);
+
+  /* eslint-disable no-await-in-loop */
+  for (let i = 1; i < 10000; i += 1) {
+    const candidate = join(dir, `${base}-${i}${ext}`);
+    if (!(await pathExists(candidate))) return candidate;
+  }
+  /* eslint-enable no-await-in-loop */
+
+  throw new Error(`Could not find a unique filename after 10000 attempts for "${desiredPath}"`);
+}

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -165,4 +165,94 @@ describe('ImapService', () => {
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
     });
   });
+
+  // -----------------------------------------------------------------------
+  // searchEmails — Power Search wiring (Phase A + B)
+  // -----------------------------------------------------------------------
+
+  describe('searchEmails (Power Search)', () => {
+    it('passes a Date to client.search when since is a YYYY-MM-DD string', async () => {
+      client.search.mockResolvedValue([]);
+
+      await service.searchEmails('test', '', { since: '2024-01-01' });
+
+      expect(client.search).toHaveBeenCalledTimes(1);
+      const [criteria] = client.search.mock.calls[0];
+      expect(criteria.since).toBeInstanceOf(Date);
+      expect((criteria.since as Date).toISOString()).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    it('applies hasAttachment post-filter only after pagination (no upfront bodyStructure fetch)', async () => {
+      // Pretend the server matches 3 UIDs; only the current page should be body-structured.
+      client.search.mockResolvedValue([1, 2, 3]);
+
+      // Mock fetch: only invoked ONCE with the page range (not the full search set).
+      // The mock yields three messages — two with attachments, one without.
+      const mockMessages = [
+        {
+          uid: 3,
+          envelope: { subject: 'A', from: [{ address: 'a@x' }], to: [], date: '2024-01-03' },
+          flags: new Set<string>(),
+          bodyStructure: { disposition: 'attachment' },
+          source: Buffer.from(''),
+        },
+        {
+          uid: 2,
+          envelope: { subject: 'B', from: [{ address: 'b@x' }], to: [], date: '2024-01-02' },
+          flags: new Set<string>(),
+          bodyStructure: { type: 'text', subtype: 'plain' },
+          source: Buffer.from(''),
+        },
+        {
+          uid: 1,
+          envelope: { subject: 'C', from: [{ address: 'c@x' }], to: [], date: '2024-01-01' },
+          flags: new Set<string>(),
+          bodyStructure: { disposition: 'attachment' },
+          source: Buffer.from(''),
+        },
+      ];
+      client.fetch.mockReturnValueOnce(
+        // eslint-disable-next-line @stylistic/wrap-iife -- mirror createMockImapClient pattern
+        (async function* gen() {
+          for (const m of mockMessages) yield m;
+        })(),
+      );
+
+      const result = await service.searchEmails('test', '', {
+        hasAttachment: true,
+        pageSize: 10,
+      });
+
+      // Fetch was called exactly ONCE with the page range — never upfront for all matches.
+      expect(client.fetch).toHaveBeenCalledTimes(1);
+      // pageUids = first `pageSize` of sorted-desc UIDs = "3,2,1"
+      expect(client.fetch.mock.calls[0][0]).toBe('3,2,1');
+
+      // Two of three messages have attachments → the filter should retain 2
+      expect(result.items).toHaveLength(2);
+      expect(result.totalApprox).toBe(true);
+    });
+
+    it('caps at MAX_SEARCH_UIDS (5000) and emits a truncation warning', async () => {
+      // Return 6000 synthetic UIDs
+      const tooMany = Array.from({ length: 6000 }, (_, i) => i + 1);
+      client.search.mockResolvedValue(tooMany);
+
+      // fetch yields nothing — we only care about the truncation warning path
+      client.fetch.mockReturnValueOnce((async function* gen() {})());
+
+      const result = await service.searchEmails('test', '', {});
+
+      expect(result.totalApprox).toBe(true);
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toMatch(/Truncated to 5000 of 6000/);
+      expect(result.total).toBe(5000);
+    });
+
+    it('throws when gmail_raw is used on non-Gmail account', async () => {
+      await expect(service.searchEmails('test', '', { gmailRaw: 'from:foo' })).rejects.toThrow(
+        /only valid on Gmail accounts/,
+      );
+    });
+  });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -18,6 +18,7 @@ function createMockImapClient() {
     messageDelete: vi.fn().mockResolvedValue(true),
     messageFlagsAdd: vi.fn().mockResolvedValue(true),
     messageFlagsRemove: vi.fn().mockResolvedValue(true),
+    append: vi.fn().mockResolvedValue({ uid: 42 }),
     _releaseFn: releaseFn,
   };
 }
@@ -163,6 +164,86 @@ describe('ImapService', () => {
       await service.setFlags('test', '10', 'INBOX', 'flag');
 
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveSentFolder
+  // -----------------------------------------------------------------------
+
+  describe('resolveSentFolder', () => {
+    it('returns account config sentFolder override when set', async () => {
+      connections.getAccount.mockReturnValue({
+        name: 'test',
+        email: 'test@example.com',
+        username: 'test@example.com',
+        sentFolder: 'My Sent',
+        imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
+        smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      });
+
+      const result = await service.resolveSentFolder('test');
+
+      expect(result).toBe('My Sent');
+      // Should not call client.list() when override is set
+      expect(client.list).not.toHaveBeenCalled();
+    });
+
+    it('finds Sent folder via SPECIAL-USE attribute', async () => {
+      client.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Sent Messages', path: 'Sent Messages', specialUse: '\\Sent' },
+      ]);
+
+      const result = await service.resolveSentFolder('test');
+
+      expect(result).toBe('Sent Messages');
+    });
+
+    it('falls back to common folder names', async () => {
+      client.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Sent Items', path: 'Sent Items' },
+      ]);
+
+      const result = await service.resolveSentFolder('test');
+
+      expect(result).toBe('Sent Items');
+    });
+
+    it('returns "Sent" as last resort when no match found', async () => {
+      client.list.mockResolvedValue([{ name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' }]);
+
+      const result = await service.resolveSentFolder('test');
+
+      expect(result).toBe('Sent');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // appendToSent
+  // -----------------------------------------------------------------------
+
+  describe('appendToSent', () => {
+    it('appends message to resolved Sent folder with \\Seen flag', async () => {
+      client.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', specialUse: '\\Sent' }]);
+
+      const rawMessage = 'From: test@example.com\r\nTo: a@b.com\r\n\r\nHello';
+
+      await service.appendToSent('test', rawMessage);
+
+      expect(client.append).toHaveBeenCalledWith('Sent', Buffer.from(rawMessage), ['\\Seen']);
+    });
+
+    it('uses custom flags when provided', async () => {
+      client.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', specialUse: '\\Sent' }]);
+
+      await service.appendToSent('test', 'raw msg', ['\\Seen', '\\Flagged']);
+
+      expect(client.append).toHaveBeenCalledWith('Sent', Buffer.from('raw msg'), [
+        '\\Seen',
+        '\\Flagged',
+      ]);
     });
   });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-sync -- tests use sync fs helpers for setup/teardown */
 import type { IConnectionManager } from '../connections/types.js';
 import ImapService from './imap.service.js';
 
@@ -583,6 +584,140 @@ describe('ImapService', () => {
       });
       // No ℹ️-prefixed remap notices should exist — the preflight never ran.
       expect(result.warnings?.some((w) => w.error.startsWith('ℹ️')) ?? false).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // saveAttachmentToDisk — direct-to-disk, no base64 hop (PR 4)
+  // -----------------------------------------------------------------------
+
+  describe('saveAttachmentToDisk', () => {
+    // Minimal bodyStructure with one attachment part — mirrors the shape
+    // imapflow produces.
+    const attachmentBodyStructure = {
+      type: 'multipart/mixed',
+      childNodes: [
+        { type: 'text/plain', size: 50 },
+        {
+          type: 'application/pdf',
+          size: 2048,
+          part: '2',
+          disposition: 'attachment',
+          dispositionParameters: { filename: 'lease.pdf' },
+        },
+      ],
+    };
+
+    async function* asyncFrom(chunks: Buffer[]): AsyncGenerator<Buffer> {
+      for (const c of chunks) yield c;
+    }
+
+    // Set up the client mock used by every case below.
+    function primeClientForDownload(
+      tmpClient: ReturnType<typeof createMockImapClient>,
+      payload = Buffer.from('PDF-BYTES'),
+    ) {
+      const withMethods = tmpClient as unknown as {
+        fetchOne: ReturnType<typeof vi.fn>;
+        download: ReturnType<typeof vi.fn>;
+      };
+      withMethods.fetchOne = vi.fn().mockResolvedValue({
+        uid: 42,
+        bodyStructure: attachmentBodyStructure,
+      });
+      withMethods.download = vi.fn().mockResolvedValue({
+        content: asyncFrom([payload]),
+      });
+    }
+
+    it('writes an attachment to a tmp-dir path and returns {path, size, mimeType}', async () => {
+      const { mkdtempSync, rmSync, readFileSync } = await import('node:fs');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      const tmp = mkdtempSync(join(tmpdir(), 'save-att-'));
+      try {
+        primeClientForDownload(client, Buffer.from('PDF-PAYLOAD'));
+
+        const result = await service.saveAttachmentToDisk(
+          'test',
+          '42',
+          'INBOX',
+          'lease.pdf',
+          tmp, // directory — filename is appended
+        );
+
+        expect(result.path).toBe(join(tmp, 'lease.pdf'));
+        expect(result.mimeType).toBe('application/pdf');
+        expect(result.size).toBe('PDF-PAYLOAD'.length);
+        expect(readFileSync(result.path, 'utf-8')).toBe('PDF-PAYLOAD');
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('auto-suffixes when target exists and overwrite=false', async () => {
+      const { mkdtempSync, rmSync, writeFileSync, readFileSync } = await import('node:fs');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      const tmp = mkdtempSync(join(tmpdir(), 'save-att-'));
+      try {
+        // Pre-seed a conflict
+        writeFileSync(join(tmp, 'lease.pdf'), 'EXISTING');
+        primeClientForDownload(client, Buffer.from('NEW-BYTES'));
+
+        const result = await service.saveAttachmentToDisk('test', '42', 'INBOX', 'lease.pdf', tmp);
+
+        expect(result.path).toBe(join(tmp, 'lease-1.pdf'));
+        expect(readFileSync(join(tmp, 'lease.pdf'), 'utf-8')).toBe('EXISTING');
+        expect(readFileSync(result.path, 'utf-8')).toBe('NEW-BYTES');
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects /etc/passwd-style destinations outside $HOME and /tmp', async () => {
+      primeClientForDownload(client);
+      await expect(
+        service.saveAttachmentToDisk('test', '42', 'INBOX', 'lease.pdf', '/etc/passwd'),
+      ).rejects.toThrow(/outside the user's home directory/);
+    });
+
+    it('rejects destinations containing `..` traversal', async () => {
+      primeClientForDownload(client);
+      // Literal `..` segment kept in the string (not normalized by path.join).
+      // Even when the resolved path would end up inside a safe dir, we reject
+      // on the raw `..` segment first.
+      await expect(
+        service.saveAttachmentToDisk(
+          'test',
+          '42',
+          'INBOX',
+          'lease.pdf',
+          '/Users/someone/Downloads/../../../etc/evil.pdf',
+        ),
+      ).rejects.toThrow(/must not contain ".." traversal segments/);
+    });
+
+    it('rejects non-absolute paths', async () => {
+      primeClientForDownload(client);
+      await expect(
+        service.saveAttachmentToDisk('test', '42', 'INBOX', 'lease.pdf', 'relative/path.pdf'),
+      ).rejects.toThrow(/absolute path/);
+    });
+
+    it('throws when the attachment filename is not found on the email', async () => {
+      const { mkdtempSync, rmSync } = await import('node:fs');
+      const { tmpdir } = await import('node:os');
+      const { join } = await import('node:path');
+      const tmp = mkdtempSync(join(tmpdir(), 'save-att-'));
+      try {
+        primeClientForDownload(client);
+        await expect(
+          service.saveAttachmentToDisk('test', '42', 'INBOX', 'not-there.pdf', tmp),
+        ).rejects.toThrow(/Attachment "not-there.pdf" not found/);
+      } finally {
+        rmSync(tmp, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -211,12 +211,12 @@ describe('ImapService', () => {
       expect(result).toBe('Sent Items');
     });
 
-    it('returns "Sent" as last resort when no match found', async () => {
+    it('throws when no Sent folder can be resolved', async () => {
       client.list.mockResolvedValue([{ name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' }]);
 
-      const result = await service.resolveSentFolder('test');
-
-      expect(result).toBe('Sent');
+      await expect(service.resolveSentFolder('test')).rejects.toThrow(
+        'Cannot resolve Sent folder for "test"',
+      );
     });
   });
 
@@ -244,6 +244,19 @@ describe('ImapService', () => {
         '\\Seen',
         '\\Flagged',
       ]);
+    });
+
+    it('retries append after creating mailbox on TRYCREATE error', async () => {
+      client.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', specialUse: '\\Sent' }]);
+      client.append
+        .mockRejectedValueOnce(new Error('[TRYCREATE] Mailbox does not exist'))
+        .mockResolvedValueOnce({ uid: 42 });
+      (client as Record<string, unknown>).mailboxCreate = vi.fn().mockResolvedValue({});
+
+      await service.appendToSent('test', 'raw msg');
+
+      expect((client as Record<string, unknown>).mailboxCreate).toHaveBeenCalledWith('Sent');
+      expect(client.append).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -255,4 +255,173 @@ describe('ImapService', () => {
       );
     });
   });
+
+  // -----------------------------------------------------------------------
+  // searchAcrossAccounts — Power Search Phase D
+  // -----------------------------------------------------------------------
+
+  describe('searchAcrossAccounts (cross-account fan-out)', () => {
+    function makeMessage(uid: number, subject: string, dateISO: string, fromAddr: string) {
+      return {
+        uid,
+        envelope: { subject, from: [{ address: fromAddr }], to: [], date: dateISO },
+        flags: new Set<string>(),
+        bodyStructure: { type: 'text', subtype: 'plain' },
+        source: Buffer.from(''),
+      };
+    }
+
+    /** Build an async-iterable that yields the given messages, avoiding IIFEs. */
+    async function* makeAsyncGen<T>(items: T[]): AsyncGenerator<T> {
+      for (const item of items) yield item;
+    }
+
+    it('merges results from two accounts, stamps .account, sorts by date desc', async () => {
+      // Two accounts → two underlying searches. `searchEmails` acquires a lock
+      // per account; in our mock all accounts share the same fake client, so
+      // the two fan-out calls queue sequentially (each UID set is queued up).
+      client.search
+        .mockResolvedValueOnce([10, 11]) // account-a uids
+        .mockResolvedValueOnce([20, 21]); // account-b uids
+
+      client.fetch
+        .mockReturnValueOnce(
+          makeAsyncGen([
+            makeMessage(11, 'A2', '2024-01-05T00:00:00Z', 'a2@example.com'),
+            makeMessage(10, 'A1', '2024-01-01T00:00:00Z', 'a1@example.com'),
+          ]),
+        )
+        .mockReturnValueOnce(
+          makeAsyncGen([
+            makeMessage(21, 'B2', '2024-01-10T00:00:00Z', 'b2@example.com'),
+            makeMessage(20, 'B1', '2024-01-03T00:00:00Z', 'b1@example.com'),
+          ]),
+        );
+
+      connections.getAccount.mockImplementation((name: string) => ({
+        name,
+        email: `${name}@example.com`,
+        username: name,
+        imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
+        smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      }));
+
+      const result = await service.searchAcrossAccounts(['account-a', 'account-b'], '', {
+        pageSize: 10,
+      });
+
+      // 4 items merged — two from each account
+      expect(result.items).toHaveLength(4);
+
+      // Date-desc order: B2 (Jan 10) > A2 (Jan 5) > B1 (Jan 3) > A1 (Jan 1)
+      expect(result.items.map((i) => i.subject)).toEqual(['B2', 'A2', 'B1', 'A1']);
+
+      // Each item must carry the originating account name.
+      expect(result.items[0].account).toBe('account-b');
+      expect(result.items[1].account).toBe('account-a');
+      expect(result.items[2].account).toBe('account-b');
+      expect(result.items[3].account).toBe('account-a');
+
+      // Total is the sum of per-account totals (2 + 2).
+      expect(result.total).toBe(4);
+
+      // No partial-failure warnings expected.
+      expect(result.warnings).toBeUndefined();
+    });
+
+    it('surfaces partial-success warnings when one account fails', async () => {
+      // account-a succeeds with one message; account-b rejects on the first
+      // IMAP call. `searchEmails` acquires a lock BEFORE searching so the
+      // second (failing) account's getMailboxLock is what we need to fail.
+      client.search.mockResolvedValueOnce([1]);
+      client.fetch.mockReturnValueOnce(
+        makeAsyncGen([makeMessage(1, 'Only A', '2024-02-01T00:00:00Z', 'a@example.com')]),
+      );
+
+      let call = 0;
+      client.getMailboxLock.mockImplementation(async () => {
+        call += 1;
+        if (call === 2) {
+          throw new Error('authentication timeout');
+        }
+        return { release: vi.fn() };
+      });
+
+      const result = await service.searchAcrossAccounts(['account-a', 'account-b'], '', {
+        pageSize: 10,
+      });
+
+      // Partial success — only account-a's item should surface.
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].account).toBe('account-a');
+
+      // The failing account must appear in warnings[] with its error.
+      expect(result.warnings).toBeDefined();
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings?.[0].account).toBe('account-b');
+      expect(result.warnings?.[0].error).toMatch(/authentication timeout/);
+
+      // Human-readable warning summary should mention the failed account.
+      expect(result.warning).toMatch(/account-b/);
+    });
+
+    it('throws when every account fails', async () => {
+      client.getMailboxLock.mockRejectedValue(new Error('boom'));
+
+      await expect(service.searchAcrossAccounts(['a', 'b'], '', { pageSize: 5 })).rejects.toThrow(
+        /All 2 accounts failed/,
+      );
+    });
+
+    it('unions facets across accounts and re-keys mailbox facet by account', async () => {
+      // Both fan-out searchEmails calls run concurrently through the same
+      // shared mock client, so we can't rely on fetch call order. Instead,
+      // route fetch results based on the UID string requested so each account
+      // gets the expected messages regardless of interleaving.
+      client.search.mockResolvedValueOnce([100]).mockResolvedValueOnce([200]);
+
+      client.fetch.mockImplementation((range: string) => {
+        // Account A's UID = 100, account B's UID = 200. Every fetch for a
+        // given account (page body + facet envelope) hits the same range
+        // string, so we can route on that. Use mid-year dates so the
+        // year-bucket math doesn't depend on the local timezone.
+        if (range === '100') {
+          return makeAsyncGen([makeMessage(100, 'A', '2024-06-15T12:00:00Z', 'x@a.example')]);
+        }
+        if (range === '200') {
+          return makeAsyncGen([makeMessage(200, 'B', '2023-06-15T12:00:00Z', 'y@b.example')]);
+        }
+        return makeAsyncGen<ReturnType<typeof makeMessage>>([]);
+      });
+
+      const result = await service.searchAcrossAccounts(['acc-a', 'acc-b'], '', {
+        pageSize: 10,
+        facets: ['sender', 'year', 'mailbox'],
+      });
+
+      // Sender facet is a union of both accounts' sender buckets.
+      expect(result.facets?.sender).toEqual({
+        'x@a.example': 1,
+        'y@b.example': 1,
+      });
+
+      // Year facet union.
+      expect(result.facets?.year).toEqual({
+        2024: 1,
+        2023: 1,
+      });
+
+      // Mailbox facet is re-keyed by account name, not by the single 'INBOX'.
+      expect(result.facets?.mailbox).toEqual({
+        'acc-a': 1,
+        'acc-b': 1,
+      });
+    });
+
+    it('throws when accountNames is empty', async () => {
+      await expect(service.searchAcrossAccounts([], '', {})).rejects.toThrow(
+        /at least one account/,
+      );
+    });
+  });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -423,5 +423,166 @@ describe('ImapService', () => {
         /at least one account/,
       );
     });
+
+    // -------------------------------------------------------------------------
+    // Auto-remap via SPECIAL-USE (Phase 3 follow-on)
+    // -------------------------------------------------------------------------
+
+    it('auto-remaps mailbox per account via SPECIAL-USE flags and emits ℹ️ notice', async () => {
+      // Account A has INBOX.Archive literally; account B only has
+      // [Gmail]/All Mail with the \All flag. Fan-out with mailbox=INBOX.Archive
+      // should search both: A on INBOX.Archive, B on [Gmail]/All Mail, with a
+      // remap notice for B.
+      const clientA = createMockImapClient();
+      const clientB = createMockImapClient();
+      clientA.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Archive', path: 'INBOX.Archive', specialUse: '\\Archive' },
+      ]);
+      clientB.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'All Mail', path: '[Gmail]/All Mail', specialUse: '\\All' },
+      ]);
+
+      clientA.search.mockResolvedValue([10]);
+      clientB.search.mockResolvedValue([20]);
+      clientA.fetch.mockReturnValueOnce(
+        makeAsyncGen([makeMessage(10, 'A archive hit', '2024-05-01T00:00:00Z', 'a@example.com')]),
+      );
+      clientB.fetch.mockReturnValueOnce(
+        makeAsyncGen([makeMessage(20, 'B all-mail hit', '2024-06-01T00:00:00Z', 'b@example.com')]),
+      );
+
+      const localConnections = {
+        getAccount: vi.fn().mockImplementation((name: string) => ({
+          name,
+          email: `${name}@example.com`,
+          username: name,
+          imap: {
+            host: 'imap.example.com',
+            port: 993,
+            tls: true,
+            starttls: false,
+            verifySsl: true,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 465,
+            tls: true,
+            starttls: false,
+            verifySsl: true,
+          },
+        })),
+        getAccountNames: vi.fn().mockReturnValue(['account-a', 'account-b']),
+        getImapClient: vi.fn().mockImplementation(async (name: string) => {
+          if (name === 'account-a') return clientA;
+          if (name === 'account-b') return clientB;
+          throw new Error(`unknown account ${name}`);
+        }),
+        getSmtpTransport: vi.fn(),
+        closeAll: vi.fn(),
+      } satisfies IConnectionManager;
+
+      const localService = new ImapService(localConnections);
+      const result = await localService.searchAcrossAccounts(['account-a', 'account-b'], '', {
+        mailbox: 'INBOX.Archive',
+        pageSize: 10,
+      });
+
+      // Both accounts participated; their items merged (B sorts ahead of A by date).
+      expect(result.items).toHaveLength(2);
+      expect(result.items.map((i) => i.account)).toEqual(['account-b', 'account-a']);
+
+      // Remap notice surfaces on the ℹ️-prefixed channel inside warnings[].
+      expect(result.warnings).toBeDefined();
+      const notice = result.warnings?.find((w) => w.account === 'account-b');
+      expect(notice).toBeDefined();
+      expect(notice?.error).toMatch(/^ℹ️/);
+      expect(notice?.error).toMatch(/Remapped "INBOX\.Archive" → "\[Gmail\]\/All Mail"/);
+      expect(notice?.error).toMatch(/\\All/);
+
+      // Account A was a literal match — no notice for it.
+      expect(result.warnings?.find((w) => w.account === 'account-a')).toBeUndefined();
+    });
+
+    it('skips accounts with no literal match AND no SPECIAL-USE equivalent', async () => {
+      // Account A: no match at all (has only INBOX). Account B: real \All match.
+      const clientA = createMockImapClient();
+      const clientB = createMockImapClient();
+      clientA.list.mockResolvedValue([{ name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' }]);
+      clientB.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'All Mail', path: '[Gmail]/All Mail', specialUse: '\\All' },
+      ]);
+
+      clientB.search.mockResolvedValue([7]);
+      clientB.fetch.mockReturnValueOnce(
+        makeAsyncGen([makeMessage(7, 'B hit', '2024-07-01T00:00:00Z', 'b@example.com')]),
+      );
+
+      const localConnections = {
+        getAccount: vi.fn().mockImplementation((name: string) => ({
+          name,
+          email: `${name}@example.com`,
+          username: name,
+          imap: {
+            host: 'imap.example.com',
+            port: 993,
+            tls: true,
+            starttls: false,
+            verifySsl: true,
+          },
+          smtp: {
+            host: 'smtp.example.com',
+            port: 465,
+            tls: true,
+            starttls: false,
+            verifySsl: true,
+          },
+        })),
+        getAccountNames: vi.fn().mockReturnValue(['account-a', 'account-b']),
+        getImapClient: vi.fn().mockImplementation(async (name: string) => {
+          if (name === 'account-a') return clientA;
+          if (name === 'account-b') return clientB;
+          throw new Error(`unknown account ${name}`);
+        }),
+        getSmtpTransport: vi.fn(),
+        closeAll: vi.fn(),
+      } satisfies IConnectionManager;
+
+      const localService = new ImapService(localConnections);
+      const result = await localService.searchAcrossAccounts(['account-a', 'account-b'], '', {
+        mailbox: 'INBOX.Archive',
+        pageSize: 10,
+      });
+
+      // Only account B's item surfaces.
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].account).toBe('account-b');
+
+      // Account A appears in warnings[] with a hard-skip message (no ℹ️ prefix).
+      expect(result.warnings).toBeDefined();
+      const skip = result.warnings?.find((w) => w.account === 'account-a');
+      expect(skip).toBeDefined();
+      expect(skip?.error).not.toMatch(/^ℹ️/);
+      expect(skip?.error).toMatch(/not found on this account/);
+    });
+
+    it('skips remap preflight entirely when mailbox is INBOX', async () => {
+      // With mailbox=INBOX, the preflight is short-circuited — client.list()
+      // should not be called as part of remap resolution. (searchEmails'
+      // own internal paths may list; the key signal is that no remap notice
+      // appears and no preflight warning leaks through.)
+      client.search.mockResolvedValue([1]);
+      client.fetch.mockReturnValueOnce(
+        makeAsyncGen([makeMessage(1, 'x', '2024-01-01T00:00:00Z', 'x@example.com')]),
+      );
+      const result = await service.searchAcrossAccounts(['account-a'], '', {
+        mailbox: 'INBOX',
+        pageSize: 10,
+      });
+      // No ℹ️-prefixed remap notices should exist — the preflight never ran.
+      expect(result.warnings?.some((w) => w.error.startsWith('ℹ️')) ?? false).toBe(false);
+    });
   });
 });

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -25,6 +25,8 @@ import type {
 } from '../types/index.js';
 import type { LabelStrategy } from './label-strategy.js';
 import { detectLabelStrategy } from './label-strategy.js';
+import type { MailboxRef } from './mailbox-resolver.js';
+import { resolveMailboxForAccount } from './mailbox-resolver.js';
 import type { SearchParams } from './search-criteria.js';
 import { buildSearchCriteria, chunkUids } from './search-criteria.js';
 
@@ -356,7 +358,84 @@ export default class ImapService {
 
   private labelStrategyPending = new Map<string, Promise<LabelStrategy>>();
 
+  /**
+   * Per-account mailbox-list cache keyed by account name. Populated lazily
+   * during `searchAcrossAccounts` fan-out to avoid issuing a `LIST` on every
+   * cross-account call. TTL'd at `MAILBOX_CACHE_TTL_MS`.
+   */
+  private mailboxListCache = new Map<string, { list: MailboxRef[]; expiresAt: number }>();
+
+  private static readonly MAILBOX_CACHE_TTL_MS = 5 * 60 * 1000;
+
+  /**
+   * Structural LIST-response flags we must NOT interpret as SPECIAL-USE.
+   * These describe the mailbox's hierarchy position, not its semantic role.
+   */
+  private static readonly STRUCTURAL_FLAGS = new Set([
+    '\\HasChildren',
+    '\\HasNoChildren',
+    '\\Noselect',
+    '\\Noinferiors',
+    '\\Marked',
+    '\\Unmarked',
+  ]);
+
+  /**
+   * Extract a SPECIAL-USE flag (e.g. `\All`, `\Sent`) from a LIST response's
+   * `flags` field — used as a fallback when the server does not populate
+   * `specialUse` directly (Gmail XLIST, some legacy Dovecot builds).
+   */
+  private static extractSpecialUseFromFlags(flagsRaw: unknown): string | undefined {
+    let candidates: unknown[] = [];
+    if (flagsRaw instanceof Set) {
+      candidates = Array.from(flagsRaw as Set<unknown>);
+    } else if (Array.isArray(flagsRaw)) {
+      candidates = flagsRaw;
+    }
+    const found = candidates.find((f) => {
+      if (typeof f !== 'string') return false;
+      if (!f.startsWith('\\')) return false;
+      return !ImapService.STRUCTURAL_FLAGS.has(f);
+    });
+    return typeof found === 'string' ? found : undefined;
+  }
+
   constructor(private connections: IConnectionManager) {}
+
+  /**
+   * Fetch (and cache) the lightweight mailbox reference list for an account.
+   * Used by `searchAcrossAccounts` to resolve mailbox aliases via SPECIAL-USE
+   * flags without issuing `LIST` on every fan-out call.
+   *
+   * imapflow's `client.list()` exposes `specialUse` as a string when present;
+   * Gmail accounts using XLIST can occasionally surface the flag in `flags`
+   * rather than `specialUse`, so we fall back to scanning `flags` for any
+   * value starting with `\` when `specialUse` is missing.
+   */
+  private async getMailboxList(accountName: string): Promise<MailboxRef[]> {
+    const cached = this.mailboxListCache.get(accountName);
+    if (cached && cached.expiresAt > Date.now()) return cached.list;
+
+    const client = await this.connections.getImapClient(accountName);
+    const raw = await client.list();
+    const list: MailboxRef[] = raw.map((m) => {
+      const rawRecord = m as unknown as Record<string, unknown>;
+      if (typeof rawRecord.specialUse === 'string') {
+        return { path: m.path, specialUse: rawRecord.specialUse };
+      }
+      // Fall back to scanning `flags` for a backslash-prefixed SPECIAL-USE
+      // flag — covers Gmail XLIST and a few older servers that report the
+      // flag in `flags` rather than `specialUse`.
+      const specialUse = ImapService.extractSpecialUseFromFlags(rawRecord.flags);
+      return { path: m.path, specialUse };
+    });
+
+    this.mailboxListCache.set(accountName, {
+      list,
+      expiresAt: Date.now() + ImapService.MAILBOX_CACHE_TTL_MS,
+    });
+    return list;
+  }
 
   private async getLabelStrategy(accountName: string): Promise<LabelStrategy> {
     const cached = this.labelStrategies.get(accountName);
@@ -905,16 +984,91 @@ export default class ImapService {
     // mailbox scans, but always fetch enough to feed the merged pagination.
     const perAccountPageSize = Math.min(pageSize * 10, CROSS_ACCOUNT_MAX_PER_ACCOUNT);
 
-    const searchOptionsPerAccount: SearchOptions = {
-      ...options,
-      page: 1,
-      pageSize: perAccountPageSize,
-    };
+    const requestedMailbox = options.mailbox;
+    // INBOX is universal across providers — skip the remap preflight entirely.
+    const needsRemapCheck =
+      typeof requestedMailbox === 'string' &&
+      requestedMailbox.length > 0 &&
+      requestedMailbox.toUpperCase() !== 'INBOX';
+
+    // Pre-flight each account: either resolve a real mailbox path or record a
+    // warning and skip. We collect `remapNotices` separately so they surface
+    // as informational (ℹ️) entries in the warnings array while hard skips
+    // land as ⚠️ entries.
+    const warnings: { account: string; error: string }[] = [];
+    const remapNotices: { account: string; error: string }[] = [];
+    // Name of each account that actually participates in the fan-out, paired
+    // with the per-account search options (remapped mailbox if applicable).
+    const participants: { name: string; options: SearchOptions }[] = [];
+
+    if (needsRemapCheck && typeof requestedMailbox === 'string') {
+      // Resolve sequentially per account; each underlying LIST is cached so
+      // repeat calls within the TTL are free. We do this sequentially to keep
+      // the cache warm deterministically and to bound concurrency on LIST.
+      // eslint-disable-next-line no-restricted-syntax
+      for (const name of accountNames) {
+        // eslint-disable-next-line no-await-in-loop
+        const list = await this.getMailboxList(name).catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          warnings.push({
+            account: name,
+            error: `Could not list mailboxes to resolve "${requestedMailbox}": ${msg}`,
+          });
+          return null;
+        });
+
+        if (list !== null) {
+          const resolved = resolveMailboxForAccount(requestedMailbox, list);
+          if (resolved.resolved === null) {
+            warnings.push({
+              account: name,
+              error: `Mailbox "${requestedMailbox}" not found on this account and no equivalent folder by SPECIAL-USE flag; skipped.`,
+            });
+          } else {
+            if (resolved.remapped) {
+              remapNotices.push({
+                account: name,
+                error: `ℹ️ Remapped "${requestedMailbox}" → "${resolved.resolved}" via ${resolved.specialUse ?? '(special-use)'} flag.`,
+              });
+            }
+            participants.push({
+              name,
+              options: {
+                ...options,
+                mailbox: resolved.resolved,
+                page: 1,
+                pageSize: perAccountPageSize,
+              },
+            });
+          }
+        }
+      }
+    } else {
+      // No remap needed — every account participates as-is.
+      accountNames.forEach((name) => {
+        participants.push({
+          name,
+          options: {
+            ...options,
+            page: 1,
+            pageSize: perAccountPageSize,
+          },
+        });
+      });
+    }
+
+    // If the preflight skipped every account (none had a literal match AND
+    // none had a SPECIAL-USE equivalent AND no LIST succeeded), surface a
+    // summary error — mirrors the "all accounts failed" path below.
+    if (participants.length === 0) {
+      const summary = warnings.map((w) => `${w.account}: ${w.error}`).join('; ');
+      throw new Error(`All ${accountNames.length} accounts failed: ${summary}`);
+    }
+
     const settled = await Promise.allSettled(
-      accountNames.map(async (name) => this.searchEmails(name, query, searchOptionsPerAccount)),
+      participants.map(async (p) => this.searchEmails(p.name, query, p.options)),
     );
 
-    const warnings: { account: string; error: string }[] = [];
     const perAccountWarnings: string[] = [];
     let totalAcross = 0;
     let totalApprox = false;
@@ -930,7 +1084,7 @@ export default class ImapService {
     const collectedItems: EmailMeta[] = [];
 
     settled.forEach((outcome, idx) => {
-      const name = accountNames[idx];
+      const { name } = participants[idx];
       if (outcome.status === 'rejected') {
         const err = outcome.reason as unknown;
         warnings.push({
@@ -975,8 +1129,9 @@ export default class ImapService {
       }
     });
 
-    // If every account failed, surface a summary error — callers expect a
-    // throw rather than an empty page for total failure.
+    // If every account failed (preflight skip + hard search failure combined),
+    // surface a summary error — callers expect a throw rather than an empty
+    // page for total failure. Remap notices don't count as failures here.
     if (warnings.length === accountNames.length) {
       const summary = warnings.map((w) => `${w.account}: ${w.error}`).join('; ');
       throw new Error(`All ${accountNames.length} accounts failed: ${summary}`);
@@ -1006,6 +1161,11 @@ export default class ImapService {
       if (anyMailbox) facetsPresent.mailbox = facetMailbox;
     }
 
+    // Merge remap notices (ℹ️) and hard warnings (⚠️-prefixed by convention)
+    // into a single warnings[] for backward compatibility. Remap notices carry
+    // the ℹ️ prefix in their `error` field; the tool layer splits on that.
+    const mergedWarnings = [...warnings, ...remapNotices];
+
     return {
       items,
       total: totalAcross,
@@ -1015,7 +1175,7 @@ export default class ImapService {
       ...(warning ? { warning } : {}),
       ...(totalApprox ? { totalApprox } : {}),
       ...(facetsPresent ? { facets: facetsPresent } : {}),
-      ...(warnings.length > 0 ? { warnings } : {}),
+      ...(mergedWarnings.length > 0 ? { warnings: mergedWarnings } : {}),
     };
   }
 

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -9,6 +9,7 @@ import type { IConnectionManager } from '../connections/types.js';
 import { sanitizeMailboxName } from '../safety/validation.js';
 import type {
   AttachmentMeta,
+  AttachmentSaveResult,
   BulkResult,
   Contact,
   DailyVolume,
@@ -23,6 +24,7 @@ import type {
   QuotaInfo,
   SenderStat,
 } from '../types/index.js';
+import { assertSafeDestination, resolveUniquePath, sanitizeFilename } from './file-paths.js';
 import type { LabelStrategy } from './label-strategy.js';
 import { detectLabelStrategy } from './label-strategy.js';
 import type { MailboxRef } from './mailbox-resolver.js';
@@ -2375,5 +2377,396 @@ export default class ImapService {
     }
 
     return parts;
+  }
+
+  // -------------------------------------------------------------------------
+  // Buffered search for export / bulk-attachment-save (PR 4)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Buffered search for the export / bulk-attachment-save tools.
+   *
+   * Runs a single-account or cross-account search and returns up to `maxRows`
+   * `EmailMeta` items. Unlike `searchEmails` / `searchAcrossAccounts` (which
+   * paginate at 100/page max), this caps at 50_000 rows — well within memory
+   * for an enveloped `EmailMeta`.
+   *
+   * - Single-account mode: pass `accountName`, leave `accountNames=null`.
+   *   Runs IMAP SEARCH once, then fetches envelopes in chunks of 100.
+   * - Multi-account mode: pass `accountNames` (non-null), leave
+   *   `accountName=null`. Fans out to per-account `searchForExport` calls and
+   *   merges by date. Each item is stamped with `.account`.
+   *
+   * Returns `{ items, truncated }` where `truncated=true` means the underlying
+   * match set exceeded `maxRows` and rows were dropped.
+   */
+  async searchForExport(
+    accountNames: string[] | null,
+    accountName: string | null,
+    query: string,
+    options: SearchOptions & { maxRows: number },
+  ): Promise<{ items: EmailMeta[]; truncated: boolean }> {
+    const { maxRows, ...searchOpts } = options;
+
+    // ------------------------------------------------------------------
+    // Multi-account — delegate per account and merge
+    // ------------------------------------------------------------------
+    if (accountNames !== null) {
+      if (accountNames.length === 0) {
+        throw new Error('searchForExport requires at least one account name');
+      }
+      const perAccountCap = maxRows; // let each account contribute up to maxRows
+      const settled = await Promise.allSettled(
+        accountNames.map(async (name) => {
+          const r = await this.searchForExport(null, name, query, {
+            ...searchOpts,
+            maxRows: perAccountCap,
+          });
+          return r;
+        }),
+      );
+
+      let merged: EmailMeta[] = [];
+      let anyTruncated = false;
+      settled.forEach((outcome, idx) => {
+        if (outcome.status === 'fulfilled') {
+          const name = accountNames[idx];
+          outcome.value.items.forEach((m) => {
+            merged.push({ ...m, account: name });
+          });
+          if (outcome.value.truncated) anyTruncated = true;
+        }
+      });
+      merged.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+      if (merged.length > maxRows) {
+        merged = merged.slice(0, maxRows);
+        anyTruncated = true;
+      }
+      return { items: merged, truncated: anyTruncated };
+    }
+
+    // ------------------------------------------------------------------
+    // Single-account — one IMAP SEARCH, chunked envelope fetch
+    // ------------------------------------------------------------------
+    if (accountName === null) {
+      throw new Error(
+        'searchForExport requires either accountNames (multi) or accountName (single)',
+      );
+    }
+    const client = await this.connections.getImapClient(accountName);
+    const account = this.connections.getAccount(accountName);
+    const isGmail = account.imap.host === 'imap.gmail.com';
+    const mailbox = sanitizeMailboxName(searchOpts.mailbox ?? 'INBOX');
+
+    const lock = await client.getMailboxLock(mailbox);
+    try {
+      const params: SearchParams = { ...(searchOpts as SearchParams), query };
+      const { criteria, postFilters } = buildSearchCriteria(params, { isGmail });
+      const searchResult = await client.search(criteria, { uid: true });
+      let uids: number[] = Array.isArray(searchResult) ? searchResult : [];
+      let truncated = false;
+
+      if (uids.length === 0) {
+        return { items: [], truncated: false };
+      }
+
+      uids.sort((a, b) => b - a);
+
+      if (uids.length > maxRows) {
+        uids = uids.slice(0, maxRows);
+        truncated = true;
+      }
+
+      let items: EmailMeta[] = [];
+      const chunks = chunkUids(uids, 100);
+      /* eslint-disable no-restricted-syntax, no-await-in-loop */
+      for (const chunk of chunks) {
+        const range = chunk.join(',');
+        for await (const msg of client.fetch(
+          range,
+          {
+            uid: true,
+            envelope: true,
+            flags: true,
+            bodyStructure: true,
+            source: { start: 0, maxLength: 256 },
+          },
+          { uid: true },
+        )) {
+          items.push(messageToEmailMeta(msg as unknown as Record<string, unknown>));
+        }
+      }
+      /* eslint-enable no-restricted-syntax, no-await-in-loop */
+
+      // Apply post-pagination filters (hasAttachment / attachment_filename /
+      // attachment_mimetype) to the full buffered set — these are cheap in
+      // memory since we already have bodyStructure-derived `attachments`.
+      if (postFilters.hasAttachment !== undefined) {
+        const want = postFilters.hasAttachment;
+        items = items.filter((m) => m.hasAttachments === want);
+      }
+      if (postFilters.attachmentFilename) {
+        const needle = postFilters.attachmentFilename.toLowerCase();
+        items = items.filter((m) => {
+          const atts = m.attachments ?? [];
+          return atts.some((a) => a.filename.toLowerCase().includes(needle));
+        });
+      }
+      if (postFilters.attachmentMimetype) {
+        let re: RegExp;
+        try {
+          re = new RegExp(postFilters.attachmentMimetype, 'i');
+        } catch (err) {
+          throw new Error(
+            `Invalid attachment_mimetype pattern: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        items = items.filter((m) => (m.attachments ?? []).some((a) => re.test(a.mimeType)));
+      }
+
+      items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+      return { items, truncated };
+    } finally {
+      lock.release();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Direct-to-disk attachment save (PR 4)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Save a single attachment directly to disk, streaming from imapflow into
+   * `fs.createWriteStream` — no base64 hop, no MCP-response byte budget, no
+   * 5 MB ceiling.
+   *
+   * `destination` may be:
+   *   - an absolute file path (e.g. `/Users/me/Downloads/lease.pdf`)
+   *   - an absolute directory (e.g. `/Users/me/Downloads`) — the attachment's
+   *     original filename is appended.
+   *
+   * Throws if the resolved destination is outside `$HOME` or `/tmp`.
+   */
+  async saveAttachmentToDisk(
+    accountName: string,
+    emailId: string,
+    mailbox: string,
+    filename: string,
+    destination: string,
+    overwrite = false,
+  ): Promise<AttachmentSaveResult> {
+    const { createWriteStream } = await import('node:fs');
+    const { mkdir, stat } = await import('node:fs/promises');
+    const { dirname, join } = await import('node:path');
+    const { pipeline } = await import('node:stream/promises');
+
+    // Resolve target — directory vs file path
+    assertSafeDestination(destination);
+    let targetPath: string;
+    try {
+      const info = await stat(destination);
+      if (info.isDirectory()) {
+        targetPath = join(destination, sanitizeFilename(filename));
+      } else {
+        targetPath = destination;
+      }
+    } catch {
+      // Destination doesn't exist yet — treat as a file path.
+      targetPath = destination;
+    }
+    // Re-check the final resolved path (defense in depth — the file component
+    // is user-supplied and could include `..` in theory).
+    assertSafeDestination(targetPath);
+
+    // Auto-collision suffix when overwrite=false.
+    const finalPath = await resolveUniquePath(targetPath, overwrite);
+    await mkdir(dirname(finalPath), { recursive: true });
+
+    const client = await this.connections.getImapClient(accountName);
+    const uid = parseInt(emailId, 10);
+    const safeMailbox = sanitizeMailboxName(mailbox);
+
+    const lock = await client.getMailboxLock(safeMailbox);
+    try {
+      const msg = await client.fetchOne(
+        String(uid),
+        { uid: true, bodyStructure: true },
+        { uid: true },
+      );
+      if (!msg) {
+        throw new Error(`Email ${emailId} not found in ${mailbox}`);
+      }
+
+      const attachments = extractAttachmentMeta(msg.bodyStructure);
+      const attachment = attachments.find((a) => a.filename === filename);
+      if (!attachment) {
+        throw new Error(
+          `Attachment "${filename}" not found. Available: ${
+            attachments.map((a) => a.filename).join(', ') || 'none'
+          }`,
+        );
+      }
+
+      const partNumber = findMimePartByFilename(msg.bodyStructure, filename);
+      if (!partNumber) {
+        throw new Error(`Could not locate MIME part for "${filename}"`);
+      }
+
+      const downloadResult = await client.download(String(uid), partNumber, { uid: true });
+      if (!downloadResult?.content) {
+        throw new Error(`Failed to download attachment "${filename}"`);
+      }
+
+      const ws = createWriteStream(finalPath);
+      await pipeline(downloadResult.content, ws);
+
+      const written = await stat(finalPath);
+      return {
+        path: finalPath,
+        size: written.size,
+        mimeType: attachment.mimeType,
+      };
+    } finally {
+      lock.release();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Batch attachment save — run a search and sweep every matching attachment
+  // -------------------------------------------------------------------------
+
+  /**
+   * Run `searchForExport` with the given filters and download every
+   * matching attachment into `destinationFolder`, optionally bucketed by
+   * date / sender / account. Designed for "year-end lease-PDF sweep" style
+   * batch exports.
+   *
+   * Filename / MIME-type filters narrow *which* attachments to save; emails
+   * without any qualifying attachment are skipped. Per-email errors are
+   * collected and returned rather than aborting the whole run.
+   */
+  async saveAllAttachmentsFromSearch(input: {
+    accountNames: string[] | null;
+    accountName: string | null;
+    query: string;
+    searchOptions: SearchOptions;
+    maxEmails: number;
+    destinationFolder: string;
+    organizeBy: 'flat' | 'date' | 'sender' | 'account';
+    attachmentFilename?: string;
+    attachmentMimetype?: string;
+  }): Promise<{
+    folder: string;
+    files_saved: number;
+    total_size: number;
+    skipped: number;
+    errors: { emailId: string; filename: string; error: string }[];
+  }> {
+    const { mkdir } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+
+    assertSafeDestination(input.destinationFolder);
+    await mkdir(input.destinationFolder, { recursive: true });
+
+    const { items } = await this.searchForExport(
+      input.accountNames,
+      input.accountName,
+      input.query,
+      { ...input.searchOptions, maxRows: input.maxEmails },
+    );
+
+    // Optional filters for *which* attachments to save.
+    const nameNeedle = input.attachmentFilename?.toLowerCase();
+    let mimeRe: RegExp | undefined;
+    if (input.attachmentMimetype) {
+      try {
+        mimeRe = new RegExp(input.attachmentMimetype, 'i');
+      } catch (err) {
+        throw new Error(
+          `Invalid attachment_mimetype pattern: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    let filesSaved = 0;
+    let totalSize = 0;
+    let skipped = 0;
+    const errors: { emailId: string; filename: string; error: string }[] = [];
+
+    /* eslint-disable no-restricted-syntax, no-await-in-loop */
+    for (const email of items) {
+      const atts = email.attachments ?? [];
+      const qualifying = atts.filter((a) => {
+        if (nameNeedle && !a.filename.toLowerCase().includes(nameNeedle)) return false;
+        if (mimeRe && !mimeRe.test(a.mimeType)) return false;
+        return true;
+      });
+
+      if (qualifying.length === 0) {
+        skipped += 1;
+      } else {
+        // Per-email account resolution — in cross-account mode EmailMeta
+        // carries `.account`; in single-account mode we use the provided
+        // accountName.
+        const accountForEmail = email.account ?? input.accountName;
+        if (!accountForEmail) {
+          errors.push({
+            emailId: email.id,
+            filename: '(n/a)',
+            error: 'Could not determine account for email',
+          });
+        } else {
+          // Subfolder strategy
+          let subfolder = input.destinationFolder;
+          if (input.organizeBy === 'date') {
+            const d = new Date(email.date);
+            const ym = Number.isNaN(d.getTime())
+              ? 'unknown-date'
+              : `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+            subfolder = join(input.destinationFolder, ym);
+          } else if (input.organizeBy === 'sender') {
+            const domain = email.from.address.includes('@')
+              ? (email.from.address.split('@')[1] ?? 'unknown-sender')
+              : 'unknown-sender';
+            subfolder = join(input.destinationFolder, sanitizeFilename(domain));
+          } else if (input.organizeBy === 'account') {
+            subfolder = join(input.destinationFolder, sanitizeFilename(accountForEmail));
+          }
+
+          await mkdir(subfolder, { recursive: true });
+
+          for (const att of qualifying) {
+            try {
+              const saved = await this.saveAttachmentToDisk(
+                accountForEmail,
+                email.id,
+                input.searchOptions.mailbox ?? 'INBOX',
+                att.filename,
+                subfolder,
+                false,
+              );
+              filesSaved += 1;
+              totalSize += saved.size;
+            } catch (err) {
+              errors.push({
+                emailId: email.id,
+                filename: att.filename,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+        }
+      }
+    }
+    /* eslint-enable no-restricted-syntax, no-await-in-loop */
+
+    return {
+      folder: input.destinationFolder,
+      files_saved: filesSaved,
+      total_size: totalSize,
+      skipped,
+      errors,
+    };
   }
 }

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -38,6 +38,51 @@ const MAX_SEARCH_UIDS = 5000;
 /** Maximum match-set size for which we'll envelope-fetch to compute facets. */
 const MAX_FACET_UIDS = 10000;
 
+/**
+ * Per-account fetch cap for `searchAcrossAccounts`. Each account is queried
+ * with `page=1` and `pageSize = min(requestedPageSize * 10, 500)` so we have
+ * enough rows to merge + paginate without fetching the full match set.
+ */
+const CROSS_ACCOUNT_MAX_PER_ACCOUNT = 500;
+
+// ---------------------------------------------------------------------------
+// Search option shape — shared between searchEmails / searchAcrossAccounts
+// ---------------------------------------------------------------------------
+
+export interface SearchOptions {
+  mailbox?: string;
+  page?: number;
+  pageSize?: number;
+  to?: string;
+  from?: string;
+  subject?: string;
+  cc?: string;
+  bcc?: string;
+  text?: string;
+  body?: string;
+  since?: string;
+  before?: string;
+  on?: string;
+  sentSince?: string;
+  sentBefore?: string;
+  seen?: boolean;
+  flagged?: boolean;
+  answered?: boolean;
+  draft?: boolean;
+  deleted?: boolean;
+  keyword?: string | string[];
+  notKeyword?: string | string[];
+  header?: Record<string, string>;
+  uids?: number[] | string;
+  hasAttachment?: boolean;
+  largerThan?: number;
+  smallerThan?: number;
+  attachmentFilename?: string;
+  attachmentMimetype?: string;
+  facets?: ('sender' | 'year' | 'mailbox')[];
+  gmailRaw?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers (must be defined before ImapService)
 // ---------------------------------------------------------------------------
@@ -825,6 +870,153 @@ export default class ImapService {
     } finally {
       lock.release();
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Cross-account search
+  // -------------------------------------------------------------------------
+
+  /**
+   * Fan-out search across multiple accounts. Executes `searchEmails` in
+   * parallel against every account, merges the per-account pages into a
+   * single date-sorted list, and paginates the merged result.
+   *
+   * Each returned item is stamped with `.account` so callers can tell
+   * where a match came from. Facet maps are unioned across accounts; the
+   * `mailbox` facet is re-keyed to the account name so the caller gets an
+   * account-level breakdown rather than a single `INBOX` bucket.
+   *
+   * Partial failures are surfaced as `warnings[]` without failing the
+   * whole call. If *every* account fails, throws a summary error.
+   */
+  async searchAcrossAccounts(
+    accountNames: string[],
+    query: string,
+    options: SearchOptions = {},
+  ): Promise<PaginatedResult<EmailMeta> & { warnings?: { account: string; error: string }[] }> {
+    if (accountNames.length === 0) {
+      throw new Error('searchAcrossAccounts requires at least one account name');
+    }
+
+    const page = options.page ?? 1;
+    const pageSize = options.pageSize ?? 20;
+
+    // Cap per-account fetch so large pageSize requests don't balloon into full
+    // mailbox scans, but always fetch enough to feed the merged pagination.
+    const perAccountPageSize = Math.min(pageSize * 10, CROSS_ACCOUNT_MAX_PER_ACCOUNT);
+
+    const searchOptionsPerAccount: SearchOptions = {
+      ...options,
+      page: 1,
+      pageSize: perAccountPageSize,
+    };
+    const settled = await Promise.allSettled(
+      accountNames.map(async (name) => this.searchEmails(name, query, searchOptionsPerAccount)),
+    );
+
+    const warnings: { account: string; error: string }[] = [];
+    const perAccountWarnings: string[] = [];
+    let totalAcross = 0;
+    let totalApprox = false;
+    // Pre-allocate facet buckets so we avoid assignment-in-expression inside
+    // the reduce loop. We strip empty buckets from the returned payload at
+    // the end of the function.
+    const facetSender: Record<string, number> = {};
+    const facetYear: Record<string, number> = {};
+    const facetMailbox: Record<string, number> = {};
+    let anySender = false;
+    let anyYear = false;
+    let anyMailbox = false;
+    const collectedItems: EmailMeta[] = [];
+
+    settled.forEach((outcome, idx) => {
+      const name = accountNames[idx];
+      if (outcome.status === 'rejected') {
+        const err = outcome.reason as unknown;
+        warnings.push({
+          account: name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+
+      const res = outcome.value;
+
+      // Stamp every item with its account so downstream callers know where
+      // the match came from.
+      res.items.forEach((item) => {
+        collectedItems.push({ ...item, account: name });
+      });
+
+      totalAcross += res.total;
+      if (res.totalApprox) totalApprox = true;
+      if (res.warning) perAccountWarnings.push(`${name}: ${res.warning}`);
+
+      if (res.facets) {
+        if (res.facets.sender) {
+          anySender = true;
+          Object.entries(res.facets.sender).forEach(([k, v]) => {
+            facetSender[k] = (facetSender[k] ?? 0) + v;
+          });
+        }
+        if (res.facets.year) {
+          anyYear = true;
+          Object.entries(res.facets.year).forEach(([k, v]) => {
+            facetYear[k] = (facetYear[k] ?? 0) + v;
+          });
+        }
+        if (res.facets.mailbox) {
+          // Re-key the mailbox facet by account — cross-account callers want
+          // to see the per-account breakdown, not a single "INBOX" bucket.
+          anyMailbox = true;
+          const sum = Object.values(res.facets.mailbox).reduce((a, b) => a + b, 0);
+          facetMailbox[name] = (facetMailbox[name] ?? 0) + sum;
+        }
+      }
+    });
+
+    // If every account failed, surface a summary error — callers expect a
+    // throw rather than an empty page for total failure.
+    if (warnings.length === accountNames.length) {
+      const summary = warnings.map((w) => `${w.account}: ${w.error}`).join('; ');
+      throw new Error(`All ${accountNames.length} accounts failed: ${summary}`);
+    }
+
+    // Merge + paginate the collected items.
+    collectedItems.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    const start = (page - 1) * pageSize;
+    const items = collectedItems.slice(start, start + pageSize);
+
+    const warningBits: string[] = [];
+    if (perAccountWarnings.length > 0) warningBits.push(perAccountWarnings.join(' | '));
+    if (warnings.length > 0) {
+      warningBits.push(
+        `${warnings.length} of ${accountNames.length} account(s) failed: ${warnings
+          .map((w) => `${w.account} (${w.error})`)
+          .join(', ')}`,
+      );
+    }
+    const warning = warningBits.length > 0 ? warningBits.join('; ') : undefined;
+
+    let facetsPresent: FacetResult | undefined;
+    if (anySender || anyYear || anyMailbox) {
+      facetsPresent = {};
+      if (anySender) facetsPresent.sender = facetSender;
+      if (anyYear) facetsPresent.year = facetYear;
+      if (anyMailbox) facetsPresent.mailbox = facetMailbox;
+    }
+
+    return {
+      items,
+      total: totalAcross,
+      page,
+      pageSize,
+      hasMore: start + pageSize < collectedItems.length,
+      ...(warning ? { warning } : {}),
+      ...(totalApprox ? { totalApprox } : {}),
+      ...(facetsPresent ? { facets: facetsPresent } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1013,16 +1013,50 @@ export default class ImapService {
     if (account.sentFolder) return account.sentFolder;
 
     const client = await this.connections.getImapClient(accountName);
-    const mailboxes = await client.list();
+    const mailboxesRaw = await client.list();
+    const mailboxes = Array.isArray(mailboxesRaw) ? mailboxesRaw : [...mailboxesRaw];
 
     // Try SPECIAL-USE attribute first
-    const specialUse = mailboxes.find((mb: { specialUse?: string }) => mb.specialUse === '\\Sent');
-    if (specialUse) return (specialUse as { path: string }).path;
+    const specialUse = mailboxes.find(
+      (mb) => typeof mb === 'object' && mb !== null && 'specialUse' in mb && mb.specialUse === '\\Sent',
+    );
+    if (
+      specialUse &&
+      typeof specialUse === 'object' &&
+      'path' in specialUse &&
+      typeof specialUse.path === 'string'
+    ) {
+      return specialUse.path;
+    }
 
     // Fall back to common names
-    const commonNames = ['Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail', 'INBOX.Sent'];
-    const paths = new Set(mailboxes.map((mb: { path: string }) => mb.path));
-    return commonNames.find((name) => paths.has(name)) ?? 'Sent';
+    const commonNames = [
+      'INBOX.Sent',
+      'Sent',
+      'Sent Items',
+      'Sent Mail',
+      '[Gmail]/Sent Mail',
+      'INBOX.Sent Items',
+      'INBOX.Sent Messages',
+    ];
+    const paths = new Set(
+      mailboxes
+        .filter(
+          (mb) => typeof mb === 'object' &&
+            mb !== null &&
+            'path' in mb &&
+            typeof (mb as unknown as Record<string, unknown>).path === 'string',
+        )
+        .map((mb) => (mb as unknown as Record<string, unknown>).path as string),
+    );
+    const match = commonNames.find((name) => paths.has(name));
+    if (!match) {
+      throw new Error(
+        `Cannot resolve Sent folder for "${accountName}". ` +
+          `Available mailboxes: ${[...paths].join(', ')}`,
+      );
+    }
+    return match;
   }
 
   /**
@@ -1035,7 +1069,28 @@ export default class ImapService {
   ): Promise<void> {
     const sentFolder = await this.resolveSentFolder(accountName);
     const client = await this.connections.getImapClient(accountName);
-    await client.append(sentFolder, Buffer.from(rawMessage), flags ?? ['\\Seen']);
+
+    try {
+      const lock = await client.getMailboxLock(sentFolder);
+      try {
+        await client.append(sentFolder, Buffer.from(rawMessage), flags ?? ['\\Seen']);
+      } finally {
+        lock.release();
+      }
+    } catch (err) {
+      // If mailbox doesn't exist, create it and retry once
+      if (err instanceof Error && /TRYCREATE|no such mailbox|not found/i.test(err.message)) {
+        await client.mailboxCreate(sentFolder);
+        const lock = await client.getMailboxLock(sentFolder);
+        try {
+          await client.append(sentFolder, Buffer.from(rawMessage), flags ?? ['\\Seen']);
+        } finally {
+          lock.release();
+        }
+        return;
+      }
+      throw err;
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -6,7 +6,7 @@
 
 import type { ImapFlow } from 'imapflow';
 import type { IConnectionManager } from '../connections/types.js';
-import { sanitizeMailboxName, sanitizeSearchQuery } from '../safety/validation.js';
+import { sanitizeMailboxName } from '../safety/validation.js';
 import type {
   AttachmentMeta,
   BulkResult,
@@ -24,6 +24,15 @@ import type {
 } from '../types/index.js';
 import type { LabelStrategy } from './label-strategy.js';
 import { detectLabelStrategy } from './label-strategy.js';
+import type { SearchParams } from './search-criteria.js';
+import { buildSearchCriteria } from './search-criteria.js';
+
+// ---------------------------------------------------------------------------
+// Limits
+// ---------------------------------------------------------------------------
+
+/** Maximum UIDs retained after the server SEARCH before pagination. */
+const MAX_SEARCH_UIDS = 5000;
 
 // ---------------------------------------------------------------------------
 // Helpers (must be defined before ImapService)
@@ -291,6 +300,7 @@ export default class ImapService {
       mailbox?: string;
       page?: number;
       pageSize?: number;
+      // Legacy (unchanged) filters — still camelCase:
       since?: string;
       before?: string;
       from?: string;
@@ -299,73 +309,89 @@ export default class ImapService {
       flagged?: boolean;
       hasAttachment?: boolean;
       answered?: boolean;
+      // Power Search additions (PR 1 phase A):
+      to?: string;
+      on?: string;
+      sentSince?: string;
+      sentBefore?: string;
+      cc?: string;
+      bcc?: string;
+      text?: string;
+      body?: string;
+      draft?: boolean;
+      deleted?: boolean;
+      keyword?: string | string[];
+      notKeyword?: string | string[];
+      header?: Record<string, string>;
+      uids?: number[] | string;
+      largerThan?: number;
+      smallerThan?: number;
+      gmailRaw?: string;
     } = {},
   ): Promise<PaginatedResult<EmailMeta>> {
     const client = await this.connections.getImapClient(accountName);
+    const account = this.connections.getAccount(accountName);
+    const isGmail = account.imap.host === 'imap.gmail.com';
     const mailbox = sanitizeMailboxName(options.mailbox ?? 'INBOX');
     const page = options.page ?? 1;
     const pageSize = options.pageSize ?? 20;
 
     const lock = await client.getMailboxLock(mailbox);
     try {
-      // Build search criteria
-      const search: Record<string, unknown> = {};
-      if (options.since) search.since = new Date(options.since);
-      if (options.before) search.before = new Date(options.before);
-      if (options.from) search.from = options.from;
-      if (options.subject) search.subject = options.subject;
-      if (options.seen !== undefined) search.seen = options.seen;
-      if (options.flagged !== undefined) search.flagged = options.flagged;
-      if (options.answered !== undefined) search.answered = options.answered;
+      const { criteria, postFilters, warnings } = buildSearchCriteria(options as SearchParams, {
+        isGmail,
+      });
 
-      // Search for matching UIDs
-      const searchResult = await client.search(search, { uid: true });
+      const searchResult = await client.search(criteria, { uid: true });
       let uids: number[] = Array.isArray(searchResult) ? searchResult : [];
+      let totalApprox = false;
 
-      // Post-filter for hasAttachment (IMAP has no native attachment search)
-      if (options.hasAttachment !== undefined && uids.length > 0) {
-        const filteredUids: number[] = [];
-        // eslint-disable-next-line no-restricted-syntax
-        for await (const msg of client.fetch(
-          uids.join(','),
-          { uid: true, bodyStructure: true },
-          { uid: true },
-        )) {
-          const raw = msg as unknown as Record<string, unknown>;
-          if (options.hasAttachment === hasAttachments(raw.bodyStructure)) {
-            filteredUids.push(raw.uid as number);
-          }
-        }
-        uids = filteredUids;
+      // Cap pre-pagination UIDs so huge folders don't balloon later work.
+      if (uids.length > MAX_SEARCH_UIDS) {
+        const originalCount = uids.length;
+        uids.sort((a, b) => b - a);
+        uids = uids.slice(0, MAX_SEARCH_UIDS);
+        totalApprox = true;
+        warnings.push(
+          `Truncated to ${MAX_SEARCH_UIDS} of ${originalCount} matches — narrow the query with more filters`,
+        );
       }
 
       if (uids.length === 0) {
+        const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
         return {
           items: [],
           total: 0,
           page,
           pageSize,
           hasMore: false,
+          ...(warning ? { warning } : {}),
+          ...(totalApprox ? { totalApprox } : {}),
         };
       }
 
-      // Sort descending (newest first) and paginate
+      // Sort descending (newest first) and paginate FIRST — the hasAttachment
+      // post-filter is applied only to the current page to avoid fetching
+      // bodyStructure for tens of thousands of messages on huge folders.
       uids.sort((a, b) => b - a);
       const total = uids.length;
       const start = (page - 1) * pageSize;
       const pageUids = uids.slice(start, start + pageSize);
 
       if (pageUids.length === 0) {
+        const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
         return {
           items: [],
           total,
           page,
           pageSize,
           hasMore: false,
+          ...(warning ? { warning } : {}),
+          ...(totalApprox ? { totalApprox } : {}),
         };
       }
 
-      const items: EmailMeta[] = [];
+      let items: EmailMeta[] = [];
       const range = pageUids.join(',');
 
       // eslint-disable-next-line no-restricted-syntax
@@ -383,15 +409,29 @@ export default class ImapService {
         items.push(messageToEmailMeta(msg as unknown as Record<string, unknown>));
       }
 
+      // Post-pagination hasAttachment filter. If it trims this page, we simply
+      // serve fewer items for the page and mark totalApprox=true — PR 1 keeps
+      // it simple; we do not backfill from later UIDs.
+      if (postFilters.hasAttachment !== undefined) {
+        const want = postFilters.hasAttachment;
+        items = items.filter((m) => m.hasAttachments === want);
+        if (items.length !== pageUids.length) {
+          totalApprox = true;
+        }
+      }
+
       // Sort by date descending
       items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
+      const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
       return {
         items,
         total,
         page,
         pageSize,
         hasMore: start + pageSize < total,
+        ...(warning ? { warning } : {}),
+        ...(totalApprox ? { totalApprox } : {}),
       };
     } finally {
       lock.release();
@@ -500,79 +540,71 @@ export default class ImapService {
       mailbox?: string;
       page?: number;
       pageSize?: number;
+      // Legacy (unchanged) filters — camelCase:
       to?: string;
       hasAttachment?: boolean;
       largerThan?: number;
       smallerThan?: number;
       answered?: boolean;
+      // Power Search additions (PR 1 phase A):
+      from?: string;
+      subject?: string;
+      cc?: string;
+      bcc?: string;
+      text?: string;
+      body?: string;
+      since?: string;
+      before?: string;
+      on?: string;
+      sentSince?: string;
+      sentBefore?: string;
+      seen?: boolean;
+      flagged?: boolean;
+      draft?: boolean;
+      deleted?: boolean;
+      keyword?: string | string[];
+      notKeyword?: string | string[];
+      header?: Record<string, string>;
+      uids?: number[] | string;
+      gmailRaw?: string;
     } = {},
   ): Promise<PaginatedResult<EmailMeta>> {
     const client = await this.connections.getImapClient(accountName);
+    const account = this.connections.getAccount(accountName);
+    const isGmail = account.imap.host === 'imap.gmail.com';
     const mailbox = sanitizeMailboxName(options.mailbox ?? 'INBOX');
     const page = options.page ?? 1;
     const pageSize = options.pageSize ?? 20;
-    const sanitizedQuery = query ? sanitizeSearchQuery(query) : '';
 
     const lock = await client.getMailboxLock(mailbox);
     try {
-      // Build search criteria — base query OR across subject/from/body
-      const baseCriteria: Record<string, unknown> = sanitizedQuery
-        ? { or: [{ subject: sanitizedQuery }, { from: sanitizedQuery }, { body: sanitizedQuery }] }
-        : {};
+      const params: SearchParams = { ...(options as SearchParams), query };
+      const { criteria, postFilters, warnings } = buildSearchCriteria(params, { isGmail });
 
-      // Build additional filters as AND conditions
-      const andConditions: Record<string, unknown>[] = [baseCriteria];
-
-      if (options.to) {
-        andConditions.push({ to: options.to });
-      }
-      if (options.largerThan !== undefined) {
-        andConditions.push({ larger: options.largerThan * 1024 });
-      }
-      if (options.smallerThan !== undefined) {
-        andConditions.push({ smaller: options.smallerThan * 1024 });
-      }
-      if (options.answered === true) {
-        andConditions.push({ answered: true });
-      } else if (options.answered === false) {
-        andConditions.push({ answered: false });
-      }
-
-      // Use the combined criteria or just the base
-      const searchCriteria =
-        andConditions.length === 1 ? baseCriteria : Object.assign({}, ...andConditions);
-
-      const searchResult = await client.search(searchCriteria, { uid: true });
+      const searchResult = await client.search(criteria, { uid: true });
       let uids: number[] = Array.isArray(searchResult) ? searchResult : [];
+      let totalApprox = false;
 
-      // Post-filter for has_attachment if requested (IMAP doesn't have native support)
-      if (options.hasAttachment !== undefined && uids.length > 0) {
-        const filteredUids: number[] = [];
-        const checkRange = uids.join(',');
-
-        // eslint-disable-next-line no-restricted-syntax
-        for await (const msg of client.fetch(
-          checkRange,
-          { uid: true, bodyStructure: true },
-          { uid: true },
-        )) {
-          const raw = msg as unknown as Record<string, unknown>;
-          const msgHasAtt = hasAttachments(raw.bodyStructure);
-          if (options.hasAttachment === msgHasAtt) {
-            filteredUids.push(raw.uid as number);
-          }
-        }
-
-        uids = filteredUids;
+      if (uids.length > MAX_SEARCH_UIDS) {
+        const originalCount = uids.length;
+        uids.sort((a, b) => b - a);
+        uids = uids.slice(0, MAX_SEARCH_UIDS);
+        totalApprox = true;
+        warnings.push(
+          `Truncated to ${MAX_SEARCH_UIDS} of ${originalCount} matches — narrow the query with more filters`,
+        );
       }
 
       if (uids.length === 0) {
+        const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
         return {
           items: [],
           total: 0,
           page,
           pageSize,
           hasMore: false,
+          ...(warning ? { warning } : {}),
+          ...(totalApprox ? { totalApprox } : {}),
         };
       }
 
@@ -582,16 +614,19 @@ export default class ImapService {
       const pageUids = uids.slice(start, start + pageSize);
 
       if (pageUids.length === 0) {
+        const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
         return {
           items: [],
           total,
           page,
           pageSize,
           hasMore: false,
+          ...(warning ? { warning } : {}),
+          ...(totalApprox ? { totalApprox } : {}),
         };
       }
 
-      const items: EmailMeta[] = [];
+      let items: EmailMeta[] = [];
       const range = pageUids.join(',');
 
       // eslint-disable-next-line no-restricted-syntax
@@ -609,14 +644,27 @@ export default class ImapService {
         items.push(messageToEmailMeta(msg as unknown as Record<string, unknown>));
       }
 
+      // Post-pagination hasAttachment filter — applied only to the current page.
+      // If filter trims items, we simply serve fewer results and mark totalApprox.
+      if (postFilters.hasAttachment !== undefined) {
+        const want = postFilters.hasAttachment;
+        items = items.filter((m) => m.hasAttachments === want);
+        if (items.length !== pageUids.length) {
+          totalApprox = true;
+        }
+      }
+
       items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
+      const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
       return {
         items,
         total,
         page,
         pageSize,
         hasMore: start + pageSize < total,
+        ...(warning ? { warning } : {}),
+        ...(totalApprox ? { totalApprox } : {}),
       };
     } finally {
       lock.release();

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -54,16 +54,6 @@ function parseAddresses(addrs: { name?: string; address?: string }[] | undefined
   return addrs.map(parseAddress);
 }
 
-function hasAttachments(bodyStructure: unknown): boolean {
-  if (!bodyStructure || typeof bodyStructure !== 'object') return false;
-  const bs = bodyStructure as Record<string, unknown>;
-  if (bs.disposition === 'attachment') return true;
-  if (Array.isArray(bs.childNodes)) {
-    return bs.childNodes.some((child: unknown) => hasAttachments(child));
-  }
-  return false;
-}
-
 /**
  * Walk a bodyStructure tree and collect attachment metadata.
  *
@@ -138,6 +128,12 @@ export function extractAttachmentMeta(bodyStructure: unknown): AttachmentMeta[] 
 
   walk(bodyStructure);
   return out;
+}
+
+function hasAttachments(bodyStructure: unknown): boolean {
+  // Delegate to the richer helper so legacy callers (e.g. getEmailStats) use
+  // the same semantics as extractAttachmentMeta / EmailMeta.hasAttachments.
+  return extractAttachmentMeta(bodyStructure).length > 0;
 }
 
 function extractAttachments(bodyStructure: unknown): AttachmentMeta[] {
@@ -231,7 +227,7 @@ function messageToEmailMeta(msg: Record<string, unknown>): EmailMeta {
     seen: flags.has('\\Seen'),
     flagged: flags.has('\\Flagged'),
     answered: flags.has('\\Answered'),
-    hasAttachments: hasAttachments(msg.bodyStructure),
+    hasAttachments: (attachments?.length ?? 0) > 0,
     labels,
     preview,
     ...(attachments !== undefined ? { attachments } : {}),

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1017,17 +1017,15 @@ export default class ImapService {
     const mailboxes = Array.isArray(mailboxesRaw) ? mailboxesRaw : [...mailboxesRaw];
 
     // Try SPECIAL-USE attribute first
-    const specialUse = mailboxes.find(
-      (mb) => typeof mb === 'object' && mb !== null && 'specialUse' in mb && mb.specialUse === '\\Sent',
-    );
-    if (
-      specialUse &&
-      typeof specialUse === 'object' &&
-      'path' in specialUse &&
-      typeof specialUse.path === 'string'
-    ) {
-      return specialUse.path;
+    function isSent(mb: unknown): mb is { specialUse: string; path: string } {
+      if (typeof mb !== 'object' || mb === null) return false;
+      if (!('specialUse' in mb) || !('path' in mb)) return false;
+      const r = mb as { specialUse: unknown; path: unknown };
+      return r.specialUse === '\\Sent' && typeof r.path === 'string';
     }
+
+    const specialUse = mailboxes.find(isSent);
+    if (specialUse) return specialUse.path;
 
     // Fall back to common names
     const commonNames = [
@@ -1039,16 +1037,14 @@ export default class ImapService {
       'INBOX.Sent Items',
       'INBOX.Sent Messages',
     ];
-    const paths = new Set(
-      mailboxes
-        .filter(
-          (mb) => typeof mb === 'object' &&
-            mb !== null &&
-            'path' in mb &&
-            typeof (mb as unknown as Record<string, unknown>).path === 'string',
-        )
-        .map((mb) => (mb as unknown as Record<string, unknown>).path as string),
-    );
+
+    function hasPath(mb: unknown): mb is { path: string } {
+      if (typeof mb !== 'object' || mb === null) return false;
+      if (!('path' in mb)) return false;
+      return typeof (mb as { path: unknown }).path === 'string';
+    }
+
+    const paths = new Set(mailboxes.filter(hasPath).map((mb) => mb.path));
     const match = commonNames.find((name) => paths.has(name));
     if (!match) {
       throw new Error(

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -16,6 +16,7 @@ import type {
   EmailAddress,
   EmailMeta,
   EmailStats,
+  FacetResult,
   LabelInfo,
   Mailbox,
   PaginatedResult,
@@ -25,7 +26,7 @@ import type {
 import type { LabelStrategy } from './label-strategy.js';
 import { detectLabelStrategy } from './label-strategy.js';
 import type { SearchParams } from './search-criteria.js';
-import { buildSearchCriteria } from './search-criteria.js';
+import { buildSearchCriteria, chunkUids } from './search-criteria.js';
 
 // ---------------------------------------------------------------------------
 // Limits
@@ -33,6 +34,9 @@ import { buildSearchCriteria } from './search-criteria.js';
 
 /** Maximum UIDs retained after the server SEARCH before pagination. */
 const MAX_SEARCH_UIDS = 5000;
+
+/** Maximum match-set size for which we'll envelope-fetch to compute facets. */
+const MAX_FACET_UIDS = 10000;
 
 // ---------------------------------------------------------------------------
 // Helpers (must be defined before ImapService)
@@ -58,6 +62,82 @@ function hasAttachments(bodyStructure: unknown): boolean {
     return bs.childNodes.some((child: unknown) => hasAttachments(child));
   }
   return false;
+}
+
+/**
+ * Walk a bodyStructure tree and collect attachment metadata.
+ *
+ * Rules (all case-insensitive; imapflow emits lowercase type/subtype strings):
+ * - A part with `disposition === 'attachment'` is always an attachment.
+ * - A part with `disposition === 'inline'` AND a Content-ID (`id` field) is
+ *   treated as an embedded inline resource (e.g. HTML image) and skipped.
+ * - A non-multipart, non-text/plain part that carries a filename/name
+ *   parameter but no disposition is also treated as an attachment (some mailers
+ *   omit Content-Disposition for PDFs etc).
+ *
+ * The helper is tolerant to missing fields — imapflow's parsed shape uses
+ * `type` as the combined `type/subtype` string (e.g. `"application/pdf"`),
+ * `dispositionParameters` and `parameters` for filename/name.
+ */
+export function extractAttachmentMeta(bodyStructure: unknown): AttachmentMeta[] {
+  const out: AttachmentMeta[] = [];
+
+  const walk = (node: unknown): void => {
+    if (!node || typeof node !== 'object') return;
+    const n = node as Record<string, unknown>;
+
+    const rawType = typeof n.type === 'string' ? n.type : '';
+    const lowerType = rawType.toLowerCase();
+    const isMultipart = lowerType.startsWith('multipart/');
+
+    // Recurse first so we cover every branch.
+    if (Array.isArray(n.childNodes)) {
+      n.childNodes.forEach((child) => {
+        walk(child);
+      });
+    }
+
+    if (isMultipart) return;
+
+    const disposition = typeof n.disposition === 'string' ? n.disposition.toLowerCase() : undefined;
+    const dispParams = (n.dispositionParameters ?? {}) as Record<string, string>;
+    const typeParams = (n.parameters ?? {}) as Record<string, string>;
+    const filename = dispParams.filename ?? dispParams.name ?? typeParams.name ?? undefined;
+    const contentId = typeof n.id === 'string' ? n.id : undefined;
+
+    // Skip inline resources that have a Content-ID (embedded HTML images).
+    if (disposition === 'inline' && contentId) return;
+
+    let isAttachment = false;
+    if (disposition === 'attachment') {
+      isAttachment = true;
+    } else if (filename) {
+      // No explicit disposition but a filename is present — treat as attachment
+      // unless it's a plain text body.
+      if (lowerType !== 'text/plain' && lowerType !== 'text/html') {
+        isAttachment = true;
+      }
+    }
+
+    if (!isAttachment) return;
+
+    // mimeType — imapflow's `type` is already `"maintype/subtype"`. Fall back
+    // gracefully if only `subtype` is set (older shapes).
+    let mimeType = lowerType;
+    if (!mimeType) {
+      const sub = typeof n.subtype === 'string' ? n.subtype.toLowerCase() : '';
+      mimeType = sub ? `application/${sub}` : 'application/octet-stream';
+    }
+
+    out.push({
+      filename: filename ?? 'unnamed',
+      mimeType,
+      size: typeof n.size === 'number' ? n.size : 0,
+    });
+  };
+
+  walk(bodyStructure);
+  return out;
 }
 
 function extractAttachments(bodyStructure: unknown): AttachmentMeta[] {
@@ -134,6 +214,12 @@ function messageToEmailMeta(msg: Record<string, unknown>): EmailMeta {
     }
   }
 
+  // Only populate attachments when bodyStructure was actually fetched. An
+  // undefined value signals "unknown" to downstream callers (e.g. post-filters
+  // should not treat an envelope-only message as definitively attachment-free).
+  const attachments =
+    msg.bodyStructure !== undefined ? extractAttachmentMeta(msg.bodyStructure) : undefined;
+
   return {
     id: String(msg.uid ?? msg.seq),
     subject: (envelope.subject as string) ?? '(no subject)',
@@ -148,6 +234,7 @@ function messageToEmailMeta(msg: Record<string, unknown>): EmailMeta {
     hasAttachments: hasAttachments(msg.bodyStructure),
     labels,
     preview,
+    ...(attachments !== undefined ? { attachments } : {}),
   };
 }
 
@@ -327,6 +414,9 @@ export default class ImapService {
       largerThan?: number;
       smallerThan?: number;
       gmailRaw?: string;
+      // PR 2 phase E additions:
+      attachmentFilename?: string;
+      attachmentMimetype?: string;
     } = {},
   ): Promise<PaginatedResult<EmailMeta>> {
     const client = await this.connections.getImapClient(accountName);
@@ -418,6 +508,31 @@ export default class ImapService {
         if (items.length !== pageUids.length) {
           totalApprox = true;
         }
+      }
+
+      // PR 2 Phase E — attachment filename / mimetype post-filters.
+      if (postFilters.attachmentFilename) {
+        const needle = postFilters.attachmentFilename.toLowerCase();
+        items = items.filter((m) => {
+          const atts = m.attachments ?? [];
+          return atts.some((a) => a.filename.toLowerCase().includes(needle));
+        });
+        if (items.length !== pageUids.length) totalApprox = true;
+      }
+      if (postFilters.attachmentMimetype) {
+        let re: RegExp;
+        try {
+          re = new RegExp(postFilters.attachmentMimetype, 'i');
+        } catch (err) {
+          throw new Error(
+            `Invalid attachment_mimetype pattern: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        items = items.filter((m) => {
+          const atts = m.attachments ?? [];
+          return atts.some((a) => re.test(a.mimeType));
+        });
+        if (items.length !== pageUids.length) totalApprox = true;
       }
 
       // Sort by date descending
@@ -567,6 +682,11 @@ export default class ImapService {
       header?: Record<string, string>;
       uids?: number[] | string;
       gmailRaw?: string;
+      // PR 2 phase E additions:
+      attachmentFilename?: string;
+      attachmentMimetype?: string;
+      // PR 2 phase G additions:
+      facets?: ('sender' | 'year' | 'mailbox')[];
     } = {},
   ): Promise<PaginatedResult<EmailMeta>> {
     const client = await this.connections.getImapClient(accountName);
@@ -613,6 +733,19 @@ export default class ImapService {
       const start = (page - 1) * pageSize;
       const pageUids = uids.slice(start, start + pageSize);
 
+      // PR 2 Phase G — faceted counts across the full (post-cap) UID set.
+      // Skip when the match set is too large to envelope-fetch efficiently.
+      let facets: FacetResult | undefined;
+      if (postFilters.facets && postFilters.facets.length > 0) {
+        if (uids.length > MAX_FACET_UIDS) {
+          warnings.push(
+            `Facets skipped — match set (${uids.length}) exceeds ${MAX_FACET_UIDS}. Add more filters to enable facets.`,
+          );
+        } else {
+          facets = await ImapService.computeFacets(client, uids, postFilters.facets, mailbox);
+        }
+      }
+
       if (pageUids.length === 0) {
         const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
         return {
@@ -623,6 +756,7 @@ export default class ImapService {
           hasMore: false,
           ...(warning ? { warning } : {}),
           ...(totalApprox ? { totalApprox } : {}),
+          ...(facets ? { facets } : {}),
         };
       }
 
@@ -654,6 +788,31 @@ export default class ImapService {
         }
       }
 
+      // PR 2 Phase E — attachment filename / mimetype post-filters.
+      if (postFilters.attachmentFilename) {
+        const needle = postFilters.attachmentFilename.toLowerCase();
+        items = items.filter((m) => {
+          const atts = m.attachments ?? [];
+          return atts.some((a) => a.filename.toLowerCase().includes(needle));
+        });
+        if (items.length !== pageUids.length) totalApprox = true;
+      }
+      if (postFilters.attachmentMimetype) {
+        let re: RegExp;
+        try {
+          re = new RegExp(postFilters.attachmentMimetype, 'i');
+        } catch (err) {
+          throw new Error(
+            `Invalid attachment_mimetype pattern: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        items = items.filter((m) => {
+          const atts = m.attachments ?? [];
+          return atts.some((a) => re.test(a.mimeType));
+        });
+        if (items.length !== pageUids.length) totalApprox = true;
+      }
+
       items.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
       const warning = warnings.length > 0 ? warnings.join('; ') : undefined;
@@ -665,10 +824,58 @@ export default class ImapService {
         hasMore: start + pageSize < total,
         ...(warning ? { warning } : {}),
         ...(totalApprox ? { totalApprox } : {}),
+        ...(facets ? { facets } : {}),
       };
     } finally {
       lock.release();
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Faceted counts — envelope-only chunk fetch used by searchEmails
+  // -------------------------------------------------------------------------
+
+  private static async computeFacets(
+    client: ImapFlow,
+    uids: number[],
+    wanted: ('sender' | 'year' | 'mailbox')[],
+    mailbox: string,
+  ): Promise<FacetResult> {
+    const result: FacetResult = {};
+    if (wanted.includes('sender')) result.sender = {};
+    if (wanted.includes('year')) result.year = {};
+    if (wanted.includes('mailbox')) result.mailbox = { [mailbox]: uids.length };
+
+    // No envelope scan required if only mailbox was requested.
+    if (!wanted.includes('sender') && !wanted.includes('year')) return result;
+
+    const CHUNK = 500;
+    const chunks = chunkUids(uids, CHUNK);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const chunk of chunks) {
+      const range = chunk.join(',');
+      // eslint-disable-next-line no-restricted-syntax, no-await-in-loop
+      for await (const msg of client.fetch(range, { uid: true, envelope: true }, { uid: true })) {
+        const raw = msg as unknown as Record<string, unknown>;
+        const env = (raw.envelope ?? {}) as Record<string, unknown>;
+        if (result.sender) {
+          const fromEntry = (env.from as Record<string, string>[] | undefined)?.[0];
+          if (fromEntry?.address) {
+            const key = fromEntry.address.toLowerCase();
+            result.sender[key] = (result.sender[key] ?? 0) + 1;
+          }
+        }
+        if (result.year && env.date) {
+          const yr = new Date(env.date as string).getFullYear();
+          if (!Number.isNaN(yr)) {
+            const k = String(yr);
+            result.year[k] = (result.year[k] ?? 0) + 1;
+          }
+        }
+      }
+    }
+
+    return result;
   }
 
   // -------------------------------------------------------------------------

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1001,6 +1001,44 @@ export default class ImapService {
   }
 
   // -------------------------------------------------------------------------
+  // Sent folder helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve the Sent folder path for an account.
+   * Uses account config override, then SPECIAL-USE attribute, then common names.
+   */
+  async resolveSentFolder(accountName: string): Promise<string> {
+    const account = this.connections.getAccount(accountName);
+    if (account.sentFolder) return account.sentFolder;
+
+    const client = await this.connections.getImapClient(accountName);
+    const mailboxes = await client.list();
+
+    // Try SPECIAL-USE attribute first
+    const specialUse = mailboxes.find((mb: { specialUse?: string }) => mb.specialUse === '\\Sent');
+    if (specialUse) return (specialUse as { path: string }).path;
+
+    // Fall back to common names
+    const commonNames = ['Sent', 'Sent Items', 'Sent Mail', '[Gmail]/Sent Mail', 'INBOX.Sent'];
+    const paths = new Set(mailboxes.map((mb: { path: string }) => mb.path));
+    return commonNames.find((name) => paths.has(name)) ?? 'Sent';
+  }
+
+  /**
+   * Append a raw RFC 822 message to the Sent folder.
+   */
+  async appendToSent(
+    accountName: string,
+    rawMessage: Buffer | string,
+    flags?: string[],
+  ): Promise<void> {
+    const sentFolder = await this.resolveSentFolder(accountName);
+    const client = await this.connections.getImapClient(accountName);
+    await client.append(sentFolder, Buffer.from(rawMessage), flags ?? ['\\Seen']);
+  }
+
+  // -------------------------------------------------------------------------
   // Draft management
   // -------------------------------------------------------------------------
 

--- a/src/services/mailbox-resolver.test.ts
+++ b/src/services/mailbox-resolver.test.ts
@@ -1,0 +1,205 @@
+import { resolveMailboxForAccount } from './mailbox-resolver.js';
+
+describe('resolveMailboxForAccount', () => {
+  // ---------------------------------------------------------------------------
+  // Literal match precedence
+  // ---------------------------------------------------------------------------
+
+  describe('literal path match', () => {
+    it('returns the literal path without remapping when it exists', () => {
+      const result = resolveMailboxForAccount('INBOX', [{ path: 'INBOX', specialUse: '\\Inbox' }]);
+      expect(result).toEqual({ resolved: 'INBOX', remapped: false });
+    });
+
+    it('prefers literal match over semantic remap when both apply', () => {
+      // `Archive` exists literally AND there's a \All folder — literal wins.
+      const result = resolveMailboxForAccount('Archive', [
+        { path: 'Archive' },
+        { path: '[Gmail]/All Mail', specialUse: '\\All' },
+      ]);
+      expect(result).toEqual({ resolved: 'Archive', remapped: false });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Archive / All Mail category
+  // ---------------------------------------------------------------------------
+
+  describe('archive / all-mail category', () => {
+    it('remaps INBOX.Archive → [Gmail]/All Mail via \\All', () => {
+      const result = resolveMailboxForAccount('INBOX.Archive', [
+        { path: '[Gmail]/All Mail', specialUse: '\\All' },
+        { path: 'INBOX', specialUse: '\\Inbox' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/All Mail',
+        remapped: true,
+        specialUse: '\\All',
+      });
+    });
+
+    it('remaps [Gmail]/All Mail → INBOX.Archive via \\Archive fallback', () => {
+      // Account has \Archive but no \All — rule falls back to \Archive.
+      const result = resolveMailboxForAccount('[Gmail]/All Mail', [
+        { path: 'INBOX.Archive', specialUse: '\\Archive' },
+        { path: 'INBOX', specialUse: '\\Inbox' },
+      ]);
+      expect(result).toEqual({
+        resolved: 'INBOX.Archive',
+        remapped: true,
+        specialUse: '\\Archive',
+      });
+    });
+
+    it('resolves a bare "Archive" name via \\All', () => {
+      const result = resolveMailboxForAccount('Archive', [
+        { path: '[Gmail]/All Mail', specialUse: '\\All' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/All Mail',
+        remapped: true,
+        specialUse: '\\All',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Sent category
+  // ---------------------------------------------------------------------------
+
+  describe('sent category', () => {
+    it('remaps INBOX.Sent → [Gmail]/Sent Mail via \\Sent', () => {
+      const result = resolveMailboxForAccount('INBOX.Sent', [
+        { path: '[Gmail]/Sent Mail', specialUse: '\\Sent' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Sent Mail',
+        remapped: true,
+        specialUse: '\\Sent',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Trash category
+  // ---------------------------------------------------------------------------
+
+  describe('trash category', () => {
+    it('remaps "Deleted Items" → [Gmail]/Trash via \\Trash', () => {
+      const result = resolveMailboxForAccount('Deleted Items', [
+        { path: '[Gmail]/Trash', specialUse: '\\Trash' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Trash',
+        remapped: true,
+        specialUse: '\\Trash',
+      });
+    });
+
+    it('remaps INBOX.Trash → Deleted Items via \\Trash', () => {
+      const result = resolveMailboxForAccount('INBOX.Trash', [
+        { path: 'Deleted Items', specialUse: '\\Trash' },
+      ]);
+      expect(result).toEqual({
+        resolved: 'Deleted Items',
+        remapped: true,
+        specialUse: '\\Trash',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Drafts category
+  // ---------------------------------------------------------------------------
+
+  describe('drafts category', () => {
+    it('remaps INBOX.Drafts → [Gmail]/Drafts via \\Drafts', () => {
+      const result = resolveMailboxForAccount('INBOX.Drafts', [
+        { path: '[Gmail]/Drafts', specialUse: '\\Drafts' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Drafts',
+        remapped: true,
+        specialUse: '\\Drafts',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Junk / Spam category
+  // ---------------------------------------------------------------------------
+
+  describe('junk category', () => {
+    it('remaps "Spam" → [Gmail]/Spam via \\Junk', () => {
+      const result = resolveMailboxForAccount('Spam', [
+        { path: '[Gmail]/Spam', specialUse: '\\Junk' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Spam',
+        remapped: true,
+        specialUse: '\\Junk',
+      });
+    });
+
+    it('remaps INBOX.Junk → Junk E-mail via \\Junk', () => {
+      const result = resolveMailboxForAccount('INBOX.Junk', [
+        { path: 'Junk E-mail', specialUse: '\\Junk' },
+      ]);
+      expect(result).toEqual({
+        resolved: 'Junk E-mail',
+        remapped: true,
+        specialUse: '\\Junk',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Flagged / Starred category
+  // ---------------------------------------------------------------------------
+
+  describe('flagged category', () => {
+    it('remaps "Starred" → [Gmail]/Starred via \\Flagged', () => {
+      const result = resolveMailboxForAccount('Starred', [
+        { path: '[Gmail]/Starred', specialUse: '\\Flagged' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Starred',
+        remapped: true,
+        specialUse: '\\Flagged',
+      });
+    });
+
+    it('remaps "Flagged" → Flagged-equivalent via \\Flagged', () => {
+      const result = resolveMailboxForAccount('Flagged', [
+        { path: '[Gmail]/Starred', specialUse: '\\Flagged' },
+      ]);
+      expect(result).toEqual({
+        resolved: '[Gmail]/Starred',
+        remapped: true,
+        specialUse: '\\Flagged',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // No match
+  // ---------------------------------------------------------------------------
+
+  describe('no equivalent found', () => {
+    it('returns null when requested name has no semantic category', () => {
+      const result = resolveMailboxForAccount('CustomFolder', [
+        { path: 'INBOX' },
+        { path: '[Gmail]/All Mail', specialUse: '\\All' },
+      ]);
+      expect(result).toEqual({ resolved: null, remapped: false });
+    });
+
+    it('returns null when category matches but no mailbox carries the flag', () => {
+      // "Archive" triggers the archive rule, but account has only INBOX.
+      const result = resolveMailboxForAccount('Archive', [
+        { path: 'INBOX', specialUse: '\\Inbox' },
+      ]);
+      expect(result).toEqual({ resolved: null, remapped: false });
+    });
+  });
+});

--- a/src/services/mailbox-resolver.ts
+++ b/src/services/mailbox-resolver.ts
@@ -1,0 +1,118 @@
+/**
+ * Mailbox resolver — maps a caller-supplied mailbox name to the real mailbox
+ * path on a given account using IMAP SPECIAL-USE flags (RFC 6154).
+ *
+ * Rationale: IMAP accounts across providers expose the same semantic folders
+ * (Archive, Sent, Trash, Drafts, Junk, Flagged) under wildly different paths.
+ * Gmail uses `[Gmail]/All Mail` where cPanel Dovecot uses `INBOX.Archive`;
+ * Exchange uses yet another structure. When `searchAcrossAccounts` fans out
+ * a single mailbox path to heterogeneous providers, we need to auto-remap
+ * to each account's equivalent folder by SPECIAL-USE flag.
+ *
+ * This helper is intentionally pure — it takes a requested name and a
+ * pre-fetched mailbox list, and returns the resolution decision. Callers
+ * own the cache/fetch of the mailbox list (see `ImapService.getMailboxList`).
+ */
+
+export interface MailboxRef {
+  path: string;
+  specialUse?: string;
+}
+
+export interface ResolveResult {
+  resolved: string | null;
+  remapped: boolean;
+  specialUse?: string;
+}
+
+// Ordered list — the first flag in each tuple is preferred; remaining flags
+// are fallbacks if the preferred flag isn't present on the server.
+interface SemanticRule {
+  match: (name: string) => boolean;
+  preferredFlags: string[];
+}
+
+// Match tokens on word boundaries within the requested mailbox name, using
+// the common hierarchy delimiters ('.', '/', '_', '-') so `INBOX.Archive`
+// and `[Gmail]/All Mail` both classify correctly.
+const ALL_TOKEN = /(^|[./_\- ])all([./_\- ]|$)/i;
+
+const RULES: SemanticRule[] = [
+  // Archive / "All Mail" → \All preferred, \Archive fallback.
+  // Checked before sent/trash/etc. so `[Gmail]/All Mail` lands on the All
+  // category rather than being misclassified.
+  {
+    match: (n) => /archive/i.test(n) || /all\s*mail/i.test(n) || ALL_TOKEN.test(n),
+    preferredFlags: ['\\All', '\\Archive'],
+  },
+  {
+    match: (n) => /sent/i.test(n),
+    preferredFlags: ['\\Sent'],
+  },
+  {
+    match: (n) => /trash/i.test(n) || /deleted/i.test(n),
+    preferredFlags: ['\\Trash'],
+  },
+  {
+    match: (n) => /draft/i.test(n),
+    preferredFlags: ['\\Drafts'],
+  },
+  {
+    match: (n) => /spam/i.test(n) || /junk/i.test(n),
+    preferredFlags: ['\\Junk'],
+  },
+  {
+    match: (n) => /flagged/i.test(n) || /starred/i.test(n),
+    preferredFlags: ['\\Flagged'],
+  },
+];
+
+function findByFlag(mailboxes: MailboxRef[], flag: string): MailboxRef | undefined {
+  return mailboxes.find((m) => m.specialUse === flag);
+}
+
+/**
+ * Resolve a requested mailbox name against the given account's mailbox list.
+ *
+ * - Literal match on `.path` always wins (never remap when the requested
+ *   name exists verbatim on the account).
+ * - Otherwise derive a semantic category from the requested name and look
+ *   up the first mailbox whose `specialUse` matches one of the preferred
+ *   flags for that category (preferred first, fallback second).
+ * - If the requested name doesn't match any known category, or no mailbox
+ *   on the account carries the preferred flag, returns `{ resolved: null }`.
+ */
+export function resolveMailboxForAccount(
+  requestedMailbox: string,
+  mailboxes: MailboxRef[],
+): ResolveResult {
+  // 1. Literal match — exact path on the account.
+  const literal = mailboxes.find((m) => m.path === requestedMailbox);
+  if (literal) {
+    return { resolved: requestedMailbox, remapped: false };
+  }
+
+  // 2. Semantic fallback — pick a category based on the requested name.
+  const rule = RULES.find((r) => r.match(requestedMailbox));
+  if (!rule) {
+    return { resolved: null, remapped: false };
+  }
+
+  // 3. Walk preferred flags in order; return the first mailbox that carries
+  //    one of them. Implemented via reduce to satisfy the repo's
+  //    no-restricted-syntax rule on raw for-of loops.
+  const flagMatch = rule.preferredFlags.reduce<{ path: string; flag: string } | null>(
+    (acc, flag) => {
+      if (acc) return acc;
+      const hit = findByFlag(mailboxes, flag);
+      return hit ? { path: hit.path, flag } : null;
+    },
+    null,
+  );
+
+  if (flagMatch) {
+    return { resolved: flagMatch.path, remapped: true, specialUse: flagMatch.flag };
+  }
+
+  return { resolved: null, remapped: false };
+}

--- a/src/services/search-criteria.test.ts
+++ b/src/services/search-criteria.test.ts
@@ -1,0 +1,185 @@
+import { buildSearchCriteria, chunkUids } from './search-criteria.js';
+
+describe('buildSearchCriteria', () => {
+  describe('empty / defaults', () => {
+    it('empty params produce empty criteria and no warnings', () => {
+      const result = buildSearchCriteria({}, { isGmail: false });
+      expect(result).toEqual({
+        criteria: {},
+        postFilters: { hasAttachment: undefined },
+        gmailRawUsed: false,
+        warnings: [],
+      });
+    });
+  });
+
+  describe('legacy parameter parity (matches imap.service.ts:519-543 shape)', () => {
+    it('produces matching merged criteria for query+to+largerThan+smallerThan+answered', () => {
+      const result = buildSearchCriteria(
+        {
+          query: 'invoice',
+          to: 'billing@example.com',
+          largerThan: 10,
+          smallerThan: 1000,
+          answered: true,
+          hasAttachment: true,
+        },
+        { isGmail: false },
+      );
+
+      // Legacy inline code merged conditions via Object.assign — same shape expected here:
+      expect(result.criteria).toEqual({
+        or: [{ subject: 'invoice' }, { from: 'invoice' }, { body: 'invoice' }],
+        to: 'billing@example.com',
+        larger: 10 * 1024,
+        smaller: 1000 * 1024,
+        answered: true,
+      });
+      // hasAttachment stays in postFilters, NOT in criteria
+      expect(result.postFilters.hasAttachment).toBe(true);
+      expect(result.gmailRawUsed).toBe(false);
+    });
+
+    it('answered: false becomes answered: false in criteria (imapflow handles UN- prefix)', () => {
+      const result = buildSearchCriteria({ answered: false }, { isGmail: false });
+      expect(result.criteria).toEqual({ answered: false });
+    });
+  });
+
+  describe('dates', () => {
+    it("since: '2024-01-01' → criteria.since is a Date instance", () => {
+      const result = buildSearchCriteria({ since: '2024-01-01' }, { isGmail: false });
+      expect((result.criteria as { since: unknown }).since).toBeInstanceOf(Date);
+      expect((result.criteria as { since: Date }).since.toISOString()).toBe(
+        '2024-01-01T00:00:00.000Z',
+      );
+    });
+
+    it("since: '7d' → criteria.since is ~7 days ago (UTC midnight)", () => {
+      const result = buildSearchCriteria({ since: '7d' }, { isGmail: false });
+      const { since } = result.criteria as { since: Date };
+      expect(since).toBeInstanceOf(Date);
+      // normalizeDate returns UTC midnight of (today - 7d). So the diff from
+      // current time is between 7d and 8d - 1ms depending on time of day.
+      const now = Date.now();
+      const diff = now - since.getTime();
+      expect(diff).toBeGreaterThanOrEqual(7 * 24 * 60 * 60 * 1000);
+      expect(diff).toBeLessThan(8 * 24 * 60 * 60 * 1000);
+    });
+
+    it('produces before / on / sentSince / sentBefore as Date instances', () => {
+      const result = buildSearchCriteria(
+        {
+          before: '2024-02-01',
+          on: '2024-02-15',
+          sentSince: '2024-01-01',
+          sentBefore: '2024-03-01',
+        },
+        { isGmail: false },
+      );
+      const c = result.criteria as Record<string, Date>;
+      expect(c.before).toBeInstanceOf(Date);
+      expect(c.on).toBeInstanceOf(Date);
+      expect(c.sentSince).toBeInstanceOf(Date);
+      expect(c.sentBefore).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('flags', () => {
+    it('flagged:true + seen:false combine correctly', () => {
+      const result = buildSearchCriteria({ flagged: true, seen: false }, { isGmail: false });
+      expect(result.criteria).toEqual({ flagged: true, seen: false });
+    });
+
+    it('supports draft and deleted', () => {
+      const result = buildSearchCriteria({ draft: true, deleted: false }, { isGmail: false });
+      expect(result.criteria).toEqual({ draft: true, deleted: false });
+    });
+  });
+
+  describe('keywords', () => {
+    it("keyword: ['urgent', 'review'] → two merged keyword conditions", () => {
+      const result = buildSearchCriteria({ keyword: ['urgent', 'review'] }, { isGmail: false });
+      // Since Object.assign merges by key, the last keyword wins in the merged object,
+      // but both must have been emitted for the compiler to AND them correctly.
+      // We assert on the presence of a keyword field whose value is the last one:
+      expect(result.criteria).toHaveProperty('keyword');
+      // Because Object.assign(...) with same keys overrides, callers that need both ANDed
+      // should pass them via separate search calls. For now, at least verify the last one sticks:
+      expect((result.criteria as { keyword: string }).keyword).toBe('review');
+    });
+
+    it('single keyword string passes through', () => {
+      const result = buildSearchCriteria({ keyword: 'urgent' }, { isGmail: false });
+      expect(result.criteria).toEqual({ keyword: 'urgent' });
+    });
+
+    it('notKeyword → unKeyword mapping', () => {
+      const result = buildSearchCriteria({ notKeyword: 'spam' }, { isGmail: false });
+      expect(result.criteria).toEqual({ unKeyword: 'spam' });
+    });
+  });
+
+  describe('headers and uids', () => {
+    it("header: { 'X-Foo': 'bar' } passes through", () => {
+      const result = buildSearchCriteria({ header: { 'X-Foo': 'bar' } }, { isGmail: false });
+      expect(result.criteria).toEqual({ header: { 'X-Foo': 'bar' } });
+    });
+
+    it('empty header object is omitted', () => {
+      const result = buildSearchCriteria({ header: {} }, { isGmail: false });
+      expect(result.criteria).toEqual({});
+    });
+
+    it('uids as number[] becomes comma-joined string', () => {
+      const result = buildSearchCriteria({ uids: [1, 2, 3] }, { isGmail: false });
+      expect(result.criteria).toEqual({ uid: '1,2,3' });
+    });
+
+    it('uids as string passes through', () => {
+      const result = buildSearchCriteria({ uids: '1:100' }, { isGmail: false });
+      expect(result.criteria).toEqual({ uid: '1:100' });
+    });
+  });
+
+  describe('gmail_raw fast path', () => {
+    it("gmailRaw: 'from:x' with isGmail:true → short-circuits", () => {
+      const result = buildSearchCriteria({ gmailRaw: 'from:x' }, { isGmail: true });
+      expect(result.gmailRawUsed).toBe(true);
+      expect(result.criteria).toEqual({ gmailRaw: 'from:x' });
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('gmailRaw with other filters → emits warning listing ignored filters', () => {
+      const result = buildSearchCriteria(
+        { gmailRaw: 'from:x', query: 'invoice', subject: 'bill' },
+        { isGmail: true },
+      );
+      expect(result.gmailRawUsed).toBe(true);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('gmail_raw takes precedence');
+      expect(result.warnings[0]).toContain('query');
+      expect(result.warnings[0]).toContain('subject');
+    });
+
+    it('gmailRaw with isGmail:false → throws', () => {
+      expect(() => buildSearchCriteria({ gmailRaw: 'from:x' }, { isGmail: false })).toThrow(
+        /only valid on Gmail accounts/,
+      );
+    });
+  });
+});
+
+describe('chunkUids', () => {
+  it('splits into fixed-size chunks', () => {
+    expect(chunkUids([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it('empty array returns empty', () => {
+    expect(chunkUids([], 10)).toEqual([]);
+  });
+
+  it('chunk larger than input returns single chunk', () => {
+    expect(chunkUids([1, 2, 3], 100)).toEqual([[1, 2, 3]]);
+  });
+});

--- a/src/services/search-criteria.test.ts
+++ b/src/services/search-criteria.test.ts
@@ -6,7 +6,12 @@ describe('buildSearchCriteria', () => {
       const result = buildSearchCriteria({}, { isGmail: false });
       expect(result).toEqual({
         criteria: {},
-        postFilters: { hasAttachment: undefined },
+        postFilters: {
+          hasAttachment: undefined,
+          attachmentFilename: undefined,
+          attachmentMimetype: undefined,
+          facets: undefined,
+        },
         gmailRawUsed: false,
         warnings: [],
       });
@@ -166,6 +171,48 @@ describe('buildSearchCriteria', () => {
       expect(() => buildSearchCriteria({ gmailRaw: 'from:x' }, { isGmail: false })).toThrow(
         /only valid on Gmail accounts/,
       );
+    });
+  });
+});
+
+describe('buildSearchCriteria — PR 2 post-filter extensions', () => {
+  it('attachmentFilename flows into postFilters (not into criteria)', () => {
+    const result = buildSearchCriteria({ attachmentFilename: 'lease' }, { isGmail: false });
+    expect(result.criteria).toEqual({});
+    expect(result.postFilters.attachmentFilename).toBe('lease');
+  });
+
+  it('attachmentMimetype flows into postFilters (not into criteria)', () => {
+    const result = buildSearchCriteria(
+      { attachmentMimetype: 'application/pdf' },
+      { isGmail: false },
+    );
+    expect(result.criteria).toEqual({});
+    expect(result.postFilters.attachmentMimetype).toBe('application/pdf');
+  });
+
+  it('facets flows into postFilters (not into criteria)', () => {
+    const result = buildSearchCriteria({ facets: ['sender', 'year'] }, { isGmail: false });
+    expect(result.criteria).toEqual({});
+    expect(result.postFilters.facets).toEqual(['sender', 'year']);
+  });
+
+  it('combining regular filters + new post-filters keeps them in their correct buckets', () => {
+    const result = buildSearchCriteria(
+      {
+        from: 'alice@x',
+        attachmentFilename: 'lease',
+        attachmentMimetype: 'application/pdf',
+        facets: ['sender'],
+      },
+      { isGmail: false },
+    );
+    expect(result.criteria).toEqual({ from: 'alice@x' });
+    expect(result.postFilters).toEqual({
+      hasAttachment: undefined,
+      attachmentFilename: 'lease',
+      attachmentMimetype: 'application/pdf',
+      facets: ['sender'],
     });
   });
 });

--- a/src/services/search-criteria.ts
+++ b/src/services/search-criteria.ts
@@ -36,6 +36,12 @@ export interface SearchParams {
   smallerThan?: number;
   // Post-pagination filters (not part of IMAP search — applied client-side):
   hasAttachment?: boolean;
+  /** Substring match (case-insensitive) against any attachment filename. */
+  attachmentFilename?: string;
+  /** Regex (case-insensitive) applied to `${type}/${subtype}` of each attachment. */
+  attachmentMimetype?: string;
+  /** Faceted counts to return alongside the paginated result. */
+  facets?: ('sender' | 'year' | 'mailbox')[];
   gmailRaw?: string;
 }
 
@@ -43,6 +49,9 @@ export interface BuildResult {
   criteria: Record<string, unknown>;
   postFilters: {
     hasAttachment?: boolean;
+    attachmentFilename?: string;
+    attachmentMimetype?: string;
+    facets?: ('sender' | 'year' | 'mailbox')[];
   };
   gmailRawUsed: boolean;
   warnings: string[];
@@ -157,7 +166,12 @@ export function buildSearchCriteria(params: SearchParams, opts: { isGmail: boole
 
   return {
     criteria,
-    postFilters: { hasAttachment: params.hasAttachment },
+    postFilters: {
+      hasAttachment: params.hasAttachment,
+      attachmentFilename: params.attachmentFilename,
+      attachmentMimetype: params.attachmentMimetype,
+      facets: params.facets,
+    },
     gmailRawUsed: false,
     warnings,
   };

--- a/src/services/search-criteria.ts
+++ b/src/services/search-criteria.ts
@@ -1,0 +1,173 @@
+/**
+ * Shared helper that translates a high-level Power Search parameter object
+ * into an imapflow search criteria object plus any post-pagination filters.
+ *
+ * Used by `ImapService.searchEmails` and `ImapService.listEmails` so the two
+ * entry points share identical filter semantics.
+ */
+
+import { sanitizeSearchQuery } from '../safety/validation.js';
+import { normalizeDate } from '../utils/date.js';
+
+export interface SearchParams {
+  query?: string;
+  to?: string;
+  from?: string;
+  subject?: string;
+  cc?: string;
+  bcc?: string;
+  text?: string;
+  body?: string;
+  since?: string;
+  before?: string;
+  on?: string;
+  sentSince?: string;
+  sentBefore?: string;
+  seen?: boolean;
+  flagged?: boolean;
+  answered?: boolean;
+  draft?: boolean;
+  deleted?: boolean;
+  keyword?: string | string[];
+  notKeyword?: string | string[];
+  header?: Record<string, string>;
+  uids?: number[] | string;
+  largerThan?: number; // tool-facing KB — multiplied to bytes here
+  smallerThan?: number;
+  // Post-pagination filters (not part of IMAP search — applied client-side):
+  hasAttachment?: boolean;
+  gmailRaw?: string;
+}
+
+export interface BuildResult {
+  criteria: Record<string, unknown>;
+  postFilters: {
+    hasAttachment?: boolean;
+  };
+  gmailRawUsed: boolean;
+  warnings: string[];
+}
+
+export function buildSearchCriteria(params: SearchParams, opts: { isGmail: boolean }): BuildResult {
+  const warnings: string[] = [];
+
+  // ---------------------------------------------------------------------------
+  // Gmail fast-path short-circuit
+  // ---------------------------------------------------------------------------
+  if (params.gmailRaw !== undefined && params.gmailRaw !== null && params.gmailRaw !== '') {
+    if (!opts.isGmail) {
+      throw new Error('gmail_raw is only valid on Gmail accounts (imap.host === "imap.gmail.com")');
+    }
+    const otherFilters = Object.keys(params).filter(
+      (k) => k !== 'gmailRaw' && params[k as keyof SearchParams] !== undefined,
+    );
+    if (otherFilters.length > 0) {
+      warnings.push(
+        `gmail_raw takes precedence — other filters ignored: ${otherFilters.join(', ')}`,
+      );
+    }
+    return {
+      criteria: { gmailRaw: params.gmailRaw },
+      postFilters: {},
+      gmailRawUsed: true,
+      warnings,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Regular filter build — AND across all conditions, OR across query fields
+  // ---------------------------------------------------------------------------
+  const andConditions: Record<string, unknown>[] = [];
+
+  // Base full-text OR query (matches current search_emails behavior)
+  if (params.query && params.query.length > 0) {
+    const q = sanitizeSearchQuery(params.query);
+    andConditions.push({
+      or: [{ subject: q }, { from: q }, { body: q }],
+    });
+  }
+
+  // Simple passthrough string fields
+  if (params.to) andConditions.push({ to: params.to });
+  if (params.from) andConditions.push({ from: params.from });
+  if (params.subject) andConditions.push({ subject: params.subject });
+  if (params.cc) andConditions.push({ cc: params.cc });
+  if (params.bcc) andConditions.push({ bcc: params.bcc });
+  if (params.text) andConditions.push({ text: params.text });
+  if (params.body) andConditions.push({ body: params.body });
+
+  // Dates
+  if (params.since) andConditions.push({ since: normalizeDate(params.since) });
+  if (params.before) andConditions.push({ before: normalizeDate(params.before) });
+  if (params.on) andConditions.push({ on: normalizeDate(params.on) });
+  if (params.sentSince) andConditions.push({ sentSince: normalizeDate(params.sentSince) });
+  if (params.sentBefore) andConditions.push({ sentBefore: normalizeDate(params.sentBefore) });
+
+  // Flags — imapflow accepts booleans and handles UN- prefixing internally
+  if (params.seen !== undefined) andConditions.push({ seen: params.seen });
+  if (params.flagged !== undefined) andConditions.push({ flagged: params.flagged });
+  if (params.answered !== undefined) andConditions.push({ answered: params.answered });
+  if (params.draft !== undefined) andConditions.push({ draft: params.draft });
+  if (params.deleted !== undefined) andConditions.push({ deleted: params.deleted });
+
+  // Keywords (custom IMAP flags / labels)
+  if (params.keyword) {
+    const kws = Array.isArray(params.keyword) ? params.keyword : [params.keyword];
+    kws.forEach((k) => {
+      andConditions.push({ keyword: k });
+    });
+  }
+  if (params.notKeyword) {
+    const kws = Array.isArray(params.notKeyword) ? params.notKeyword : [params.notKeyword];
+    // imapflow's compiler upper-cases keys; both `unKeyword` and `unkeyword` compile to UNKEYWORD.
+    kws.forEach((k) => {
+      andConditions.push({ unKeyword: k });
+    });
+  }
+
+  // Arbitrary header match (pass-through object)
+  if (params.header && Object.keys(params.header).length > 0) {
+    andConditions.push({ header: params.header });
+  }
+
+  // UIDs
+  if (params.uids !== undefined) {
+    const uidStr = Array.isArray(params.uids) ? params.uids.join(',') : params.uids;
+    if (uidStr && uidStr.length > 0) {
+      andConditions.push({ uid: uidStr });
+    }
+  }
+
+  // Size — tool accepts KB, IMAP expects bytes
+  if (params.largerThan !== undefined) {
+    andConditions.push({ larger: params.largerThan * 1024 });
+  }
+  if (params.smallerThan !== undefined) {
+    andConditions.push({ smaller: params.smallerThan * 1024 });
+  }
+
+  let criteria: Record<string, unknown>;
+  if (andConditions.length === 0) {
+    criteria = {};
+  } else if (andConditions.length === 1) {
+    [criteria] = andConditions;
+  } else {
+    criteria = Object.assign({}, ...andConditions);
+  }
+
+  return {
+    criteria,
+    postFilters: { hasAttachment: params.hasAttachment },
+    gmailRawUsed: false,
+    warnings,
+  };
+}
+
+/** Splits a UID list into fixed-size chunks — handy for bounded FETCH ranges. */
+export function chunkUids(uids: number[], chunkSize: number): number[][] {
+  const chunks: number[][] = [];
+  for (let i = 0; i < uids.length; i += chunkSize) {
+    chunks.push(uids.slice(i, i + chunkSize));
+  }
+  return chunks;
+}

--- a/src/services/search-presets.test.ts
+++ b/src/services/search-presets.test.ts
@@ -1,0 +1,121 @@
+import type { SearchPreset } from '../types/index.js';
+import { normalizePreset, SearchPresetRegistry } from './search-presets.js';
+
+describe('normalizePreset', () => {
+  it('returns camelCase fields from a snake_case raw preset', () => {
+    const raw = {
+      name: 'pines-lease',
+      description: 'Pines Rd lease paperwork',
+      accounts: ['wgs-usa', 'all-pedal'],
+      mailbox: 'INBOX',
+      query: 'Pines Rd',
+      from: 'landlord@example.com',
+      sent_since: '2024-01-01',
+      sent_before: '2024-12-31',
+      has_attachment: true,
+      attachment_filename: 'lease',
+      attachment_mimetype: 'application/pdf',
+      larger_than: 100,
+      smaller_than: 20000,
+      not_keyword: ['Archive', 'Spam'],
+      gmail_raw: '',
+      facets: ['sender' as const, 'year' as const],
+    };
+
+    const result = normalizePreset(raw);
+
+    expect(result.name).toBe('pines-lease');
+    expect(result.accounts).toEqual(['wgs-usa', 'all-pedal']);
+    expect(result.sentSince).toBe('2024-01-01');
+    expect(result.sentBefore).toBe('2024-12-31');
+    expect(result.hasAttachment).toBe(true);
+    expect(result.attachmentFilename).toBe('lease');
+    expect(result.attachmentMimetype).toBe('application/pdf');
+    expect(result.largerThan).toBe(100);
+    expect(result.smallerThan).toBe(20000);
+    expect(result.notKeyword).toEqual(['Archive', 'Spam']);
+    expect(result.gmailRaw).toBe('');
+    expect(result.facets).toEqual(['sender', 'year']);
+  });
+
+  it('accepts an account-only preset (single-account)', () => {
+    const result = normalizePreset({
+      name: 'urgent-only',
+      account: 'primary',
+      flagged: true,
+    });
+    expect(result.account).toBe('primary');
+    expect(result.flagged).toBe(true);
+    expect(result.accounts).toBeUndefined();
+  });
+
+  it('accepts an accounts-only preset (cross-account)', () => {
+    const result = normalizePreset({
+      name: 'all-inbox-flagged',
+      accounts: ['a', 'b'],
+      flagged: true,
+    });
+    expect(result.accounts).toEqual(['a', 'b']);
+    expect(result.account).toBeUndefined();
+  });
+
+  it('rejects when both account and accounts are provided', () => {
+    expect(() =>
+      normalizePreset({
+        name: 'conflict',
+        account: 'primary',
+        accounts: ['a', 'b'],
+      }),
+    ).toThrow(/account.*accounts|account'.*'accounts/);
+  });
+
+  it('rejects when name is empty', () => {
+    expect(() => normalizePreset({ name: '' })).toThrow();
+  });
+});
+
+describe('SearchPresetRegistry', () => {
+  const presets: SearchPreset[] = [
+    { name: 'alpha', from: 'a@example.com' },
+    { name: 'beta', subject: 'b' },
+    { name: 'gamma', accounts: ['acc1', 'acc2'] },
+  ];
+
+  it('lookup by name returns the preset', () => {
+    const registry = new SearchPresetRegistry(presets);
+    expect(registry.get('alpha')?.from).toBe('a@example.com');
+    expect(registry.get('beta')?.subject).toBe('b');
+    expect(registry.get('gamma')?.accounts).toEqual(['acc1', 'acc2']);
+  });
+
+  it('returns undefined for unknown name', () => {
+    const registry = new SearchPresetRegistry(presets);
+    expect(registry.get('does-not-exist')).toBeUndefined();
+  });
+
+  it('list() returns all presets in insertion order', () => {
+    const registry = new SearchPresetRegistry(presets);
+    expect(registry.list().map((p) => p.name)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('size reflects the registered count', () => {
+    const registry = new SearchPresetRegistry(presets);
+    expect(registry.size).toBe(3);
+  });
+
+  it('empty registry behaves correctly', () => {
+    const registry = new SearchPresetRegistry();
+    expect(registry.size).toBe(0);
+    expect(registry.list()).toEqual([]);
+    expect(registry.get('anything')).toBeUndefined();
+  });
+
+  it('last preset wins when names collide', () => {
+    const registry = new SearchPresetRegistry([
+      { name: 'dup', from: 'first' },
+      { name: 'dup', from: 'second' },
+    ]);
+    expect(registry.get('dup')?.from).toBe('second');
+    expect(registry.size).toBe(1);
+  });
+});

--- a/src/services/search-presets.ts
+++ b/src/services/search-presets.ts
@@ -1,0 +1,84 @@
+/**
+ * Saved-search preset registry — looks up `[[searches]]` entries from
+ * config.toml by name and exposes a simple list/get API consumed by the
+ * `run_preset` and `list_presets` tools.
+ *
+ * Presets are camelCase at this layer (see `SearchPreset` in
+ * `src/types/index.ts`); snake_case → camelCase normalization happens in the
+ * config loader. The `normalizePreset` helper exported here is a convenience
+ * for tests that want to exercise the snake_case → camelCase transform
+ * without going through the full config loader.
+ */
+
+import { SearchPresetSchema } from '../config/schema.js';
+import type { SearchPreset } from '../types/index.js';
+
+/**
+ * Normalize a raw (snake_case) preset into the camelCase runtime shape. Runs
+ * the Zod schema first so callers also get validation (e.g. the
+ * `account` XOR `accounts` refinement). Throws on invalid input.
+ */
+export function normalizePreset(raw: unknown): SearchPreset {
+  const parsed = SearchPresetSchema.parse(raw);
+  return {
+    name: parsed.name,
+    description: parsed.description,
+    account: parsed.account,
+    accounts: parsed.accounts,
+    mailbox: parsed.mailbox,
+    query: parsed.query,
+    to: parsed.to,
+    from: parsed.from,
+    subject: parsed.subject,
+    cc: parsed.cc,
+    bcc: parsed.bcc,
+    text: parsed.text,
+    body: parsed.body,
+    since: parsed.since,
+    before: parsed.before,
+    on: parsed.on,
+    sentSince: parsed.sent_since,
+    sentBefore: parsed.sent_before,
+    seen: parsed.seen,
+    flagged: parsed.flagged,
+    answered: parsed.answered,
+    draft: parsed.draft,
+    deleted: parsed.deleted,
+    keyword: parsed.keyword,
+    notKeyword: parsed.not_keyword,
+    header: parsed.header,
+    largerThan: parsed.larger_than,
+    smallerThan: parsed.smaller_than,
+    hasAttachment: parsed.has_attachment,
+    attachmentFilename: parsed.attachment_filename,
+    attachmentMimetype: parsed.attachment_mimetype,
+    facets: parsed.facets,
+    gmailRaw: parsed.gmail_raw,
+  };
+}
+
+/** In-memory lookup for saved-search presets keyed by `name`. */
+export class SearchPresetRegistry {
+  private readonly presets = new Map<string, SearchPreset>();
+
+  constructor(presets: SearchPreset[] = []) {
+    presets.forEach((p) => {
+      this.presets.set(p.name, p);
+    });
+  }
+
+  /** All presets, in insertion order. */
+  list(): SearchPreset[] {
+    return [...this.presets.values()];
+  }
+
+  /** Lookup a preset by name. Returns `undefined` for unknown names. */
+  get(name: string): SearchPreset | undefined {
+    return this.presets.get(name);
+  }
+
+  /** Number of presets registered. */
+  get size(): number {
+    return this.presets.size;
+  }
+}

--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -13,7 +13,10 @@ function createMockTransport() {
   };
 }
 
-function createMockConnectionManager(mockTransport: ReturnType<typeof createMockTransport>) {
+function createMockConnectionManager(
+  mockTransport: ReturnType<typeof createMockTransport>,
+  accountOverrides: Record<string, unknown> = {},
+) {
   return {
     getAccount: vi.fn().mockReturnValue({
       name: 'test',
@@ -22,6 +25,7 @@ function createMockConnectionManager(mockTransport: ReturnType<typeof createMock
       username: 'test@example.com',
       imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
       smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      ...accountOverrides,
     }),
     getAccountNames: vi.fn().mockReturnValue(['test']),
     getImapClient: vi.fn(),
@@ -37,8 +41,36 @@ function createMockRateLimiter(allowed = true) {
   } as unknown as RateLimiter;
 }
 
+function createMockEmail(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '42',
+    subject: 'Original Subject',
+    from: { name: 'Sender', address: 'sender@example.com' },
+    to: [{ name: 'Test User', address: 'test@example.com' }],
+    cc: [],
+    bodyText: 'Original body',
+    bodyHtml: undefined,
+    messageId: '<original@example.com>',
+    inReplyTo: undefined,
+    references: [],
+    date: '2025-01-01',
+    seen: true,
+    flagged: false,
+    answered: false,
+    hasAttachments: false,
+    labels: [],
+    attachments: [],
+    headers: {},
+    ...overrides,
+  };
+}
+
 function createMockImapService() {
-  return {} as unknown as ImapService;
+  return {
+    appendToSent: vi.fn().mockResolvedValue(undefined),
+    resolveSentFolder: vi.fn().mockResolvedValue('Sent'),
+    getEmail: vi.fn().mockResolvedValue(createMockEmail()),
+  } as unknown as ImapService;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,13 +81,15 @@ describe('SmtpService', () => {
   let transport: ReturnType<typeof createMockTransport>;
   let connections: ReturnType<typeof createMockConnectionManager>;
   let rateLimiter: RateLimiter;
+  let imapService: ReturnType<typeof createMockImapService>;
   let service: SmtpService;
 
   beforeEach(() => {
     transport = createMockTransport();
     connections = createMockConnectionManager(transport);
     rateLimiter = createMockRateLimiter(true);
-    service = new SmtpService(connections, rateLimiter, createMockImapService());
+    imapService = createMockImapService();
+    service = new SmtpService(connections, rateLimiter, imapService as unknown as ImapService);
   });
 
   describe('sendEmail', () => {
@@ -82,7 +116,7 @@ describe('SmtpService', () => {
 
     it('throws when rate limited', async () => {
       rateLimiter = createMockRateLimiter(false);
-      service = new SmtpService(connections, rateLimiter, createMockImapService());
+      service = new SmtpService(connections, rateLimiter, imapService as unknown as ImapService);
 
       await expect(
         service.sendEmail('test', {
@@ -123,6 +157,158 @@ describe('SmtpService', () => {
       const call = transport.sendMail.mock.calls[0][0];
       expect(call.html).toBe('<h1>Hello</h1>');
       expect(call.text).toBeUndefined();
+    });
+
+    it('calls appendToSent after successful send', async () => {
+      await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(imapService.appendToSent).toHaveBeenCalledWith(
+        'test',
+        expect.stringContaining('Subject: Hello'),
+      );
+    });
+
+    it('skips appendToSent for Gmail accounts', async () => {
+      connections = createMockConnectionManager(transport, {
+        imap: { host: 'imap.gmail.com', port: 993, tls: true, starttls: false, verifySsl: true },
+        smtp: { host: 'smtp.gmail.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      });
+      service = new SmtpService(connections, rateLimiter, imapService as unknown as ImapService);
+
+      await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(imapService.appendToSent).not.toHaveBeenCalled();
+    });
+
+    it('skips appendToSent when saveToSent is false', async () => {
+      connections = createMockConnectionManager(transport, { saveToSent: false });
+      service = new SmtpService(connections, rateLimiter, imapService as unknown as ImapService);
+
+      await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(imapService.appendToSent).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when appendToSent fails', async () => {
+      vi.mocked(imapService.appendToSent).mockRejectedValue(new Error('IMAP connection lost'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(result.status).toBe('sent');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to save to Sent folder'),
+        expect.any(Error),
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('forces appendToSent for Gmail when gmailAutoSave is false', async () => {
+      connections = createMockConnectionManager(transport, {
+        imap: { host: 'imap.gmail.com', port: 993, tls: true, starttls: false, verifySsl: true },
+        smtp: { host: 'smtp.gmail.com', port: 465, tls: true, starttls: false, verifySsl: true },
+        gmailAutoSave: false,
+      });
+      service = new SmtpService(connections, rateLimiter, imapService as unknown as ImapService);
+
+      await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(imapService.appendToSent).toHaveBeenCalled();
+    });
+  });
+
+  describe('replyToEmail', () => {
+    it('calls appendToSent after successful reply', async () => {
+      await service.replyToEmail('test', {
+        emailId: '42',
+        body: 'Reply body',
+      });
+
+      expect(imapService.appendToSent).toHaveBeenCalledWith(
+        'test',
+        expect.stringContaining('Subject: Re: Original Subject'),
+      );
+    });
+  });
+
+  describe('forwardEmail', () => {
+    it('calls appendToSent after successful forward', async () => {
+      await service.forwardEmail('test', {
+        emailId: '42',
+        to: ['forward@example.com'],
+        body: 'FYI',
+      });
+
+      expect(imapService.appendToSent).toHaveBeenCalledWith(
+        'test',
+        expect.stringContaining('Subject: Fwd: Original Subject'),
+      );
+    });
+  });
+
+  describe('sendDraft', () => {
+    it('appends to Sent before deleting draft', async () => {
+      const mockDraft = {
+        email: {
+          id: '1',
+          subject: 'Draft Subject',
+          from: { address: 'test@example.com' },
+          to: [{ address: 'recipient@example.com' }],
+          cc: [],
+          bodyText: 'Draft body',
+          bodyHtml: undefined,
+          messageId: '<draft@example.com>',
+          inReplyTo: undefined,
+          references: [],
+          date: '2025-01-01',
+          seen: false,
+          flagged: false,
+          answered: false,
+          hasAttachments: false,
+          labels: [],
+          attachments: [],
+          headers: {},
+        },
+        mailbox: 'Drafts',
+      };
+
+      const imapServiceWithDraft = {
+        appendToSent: vi.fn().mockResolvedValue(undefined),
+        resolveSentFolder: vi.fn().mockResolvedValue('Sent'),
+        getEmail: vi.fn().mockResolvedValue(createMockEmail()),
+        fetchDraft: vi.fn().mockResolvedValue(mockDraft),
+        deleteDraft: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ImapService;
+
+      service = new SmtpService(connections, rateLimiter, imapServiceWithDraft);
+
+      await service.sendDraft('test', 1);
+
+      // Verify order: appendToSent called before deleteDraft
+      const appendCall = vi.mocked(imapServiceWithDraft.appendToSent).mock.invocationCallOrder[0];
+      const deleteCall = vi.mocked(imapServiceWithDraft.deleteDraft).mock.invocationCallOrder[0];
+      expect(appendCall).toBeLessThan(deleteCall);
     });
   });
 });

--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -268,7 +268,7 @@ describe('SmtpService', () => {
   });
 
   describe('sendDraft', () => {
-    it('appends to Sent before deleting draft', async () => {
+    function createDraftMocks() {
       const mockDraft = {
         email: {
           id: '1',
@@ -301,6 +301,11 @@ describe('SmtpService', () => {
         deleteDraft: vi.fn().mockResolvedValue(undefined),
       } as unknown as ImapService;
 
+      return { mockDraft, imapServiceWithDraft };
+    }
+
+    it('appends to Sent before deleting draft', async () => {
+      const { imapServiceWithDraft } = createDraftMocks();
       service = new SmtpService(connections, rateLimiter, imapServiceWithDraft);
 
       await service.sendDraft('test', 1);
@@ -309,6 +314,31 @@ describe('SmtpService', () => {
       const appendCall = vi.mocked(imapServiceWithDraft.appendToSent).mock.invocationCallOrder[0];
       const deleteCall = vi.mocked(imapServiceWithDraft.deleteDraft).mock.invocationCallOrder[0];
       expect(appendCall).toBeLessThan(deleteCall);
+    });
+
+    it('calls appendToSent with draft content', async () => {
+      const { imapServiceWithDraft } = createDraftMocks();
+      service = new SmtpService(connections, rateLimiter, imapServiceWithDraft);
+
+      await service.sendDraft('test', 1);
+
+      expect(imapServiceWithDraft.appendToSent).toHaveBeenCalledWith(
+        'test',
+        expect.stringContaining('Subject: Draft Subject'),
+      );
+    });
+
+    it('still deletes draft when appendToSent fails', async () => {
+      const { imapServiceWithDraft } = createDraftMocks();
+      vi.mocked(imapServiceWithDraft.appendToSent).mockRejectedValue(new Error('IMAP error'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      service = new SmtpService(connections, rateLimiter, imapServiceWithDraft);
+
+      await service.sendDraft('test', 1);
+
+      // appendToSentFolder swallows errors, so deleteDraft should still be called
+      expect(imapServiceWithDraft.deleteDraft).toHaveBeenCalledWith('test', 1, 'Drafts');
+      warnSpy.mockRestore();
     });
   });
 });

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -4,6 +4,8 @@
  * No MCP dependency — fully unit-testable.
  */
 
+import { randomUUID } from 'node:crypto';
+
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
 import type { AccountConfig, SendResult } from '../types/index.js';
@@ -15,6 +17,11 @@ import type ImapService from './imap.service.js';
 
 function isGmailAccount(account: AccountConfig): boolean {
   return account.imap.host.includes('gmail.com') || account.smtp.host.includes('gmail.com');
+}
+
+function encodeRfc2047(value: string): string {
+  if (/^[\x20-\x7E]*$/.test(value)) return value;
+  return `=?UTF-8?B?${Buffer.from(value, 'utf-8').toString('base64')}?=`;
 }
 
 function buildRawMessage(options: {
@@ -32,16 +39,19 @@ function buildRawMessage(options: {
   lines.push(`From: ${options.from}`);
   lines.push(`To: ${options.to}`);
   if (options.cc) lines.push(`Cc: ${options.cc}`);
-  lines.push(`Subject: ${options.subject}`);
+  lines.push(`Subject: ${encodeRfc2047(options.subject)}`);
   lines.push(`Date: ${new Date().toUTCString()}`);
-  lines.push(`Message-ID: ${options.messageId}`);
+  const mid = options.messageId || `<${randomUUID()}@email-mcp.local>`;
+  lines.push(`Message-ID: ${mid}`);
   lines.push('MIME-Version: 1.0');
   if (options.inReplyTo) lines.push(`In-Reply-To: ${options.inReplyTo}`);
   if (options.references) lines.push(`References: ${options.references}`);
   const contentType = options.html ? 'text/html; charset=utf-8' : 'text/plain; charset=utf-8';
   lines.push(`Content-Type: ${contentType}`);
+  lines.push('Content-Transfer-Encoding: 8bit');
   lines.push('');
-  lines.push(options.body);
+  const normalizedBody = options.body.replace(/\r?\n/g, '\r\n');
+  lines.push(normalizedBody);
   return lines.join('\r\n');
 }
 

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -6,8 +6,44 @@
 
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
-import type { SendResult } from '../types/index.js';
+import type { AccountConfig, SendResult } from '../types/index.js';
 import type ImapService from './imap.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers (must be defined before SmtpService)
+// ---------------------------------------------------------------------------
+
+function isGmailAccount(account: AccountConfig): boolean {
+  return account.imap.host.includes('gmail.com') || account.smtp.host.includes('gmail.com');
+}
+
+function buildRawMessage(options: {
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  cc?: string;
+  messageId: string;
+  inReplyTo?: string;
+  references?: string;
+  html?: boolean;
+}): string {
+  const lines: string[] = [];
+  lines.push(`From: ${options.from}`);
+  lines.push(`To: ${options.to}`);
+  if (options.cc) lines.push(`Cc: ${options.cc}`);
+  lines.push(`Subject: ${options.subject}`);
+  lines.push(`Date: ${new Date().toUTCString()}`);
+  lines.push(`Message-ID: ${options.messageId}`);
+  lines.push('MIME-Version: 1.0');
+  if (options.inReplyTo) lines.push(`In-Reply-To: ${options.inReplyTo}`);
+  if (options.references) lines.push(`References: ${options.references}`);
+  const contentType = options.html ? 'text/html; charset=utf-8' : 'text/plain; charset=utf-8';
+  lines.push(`Content-Type: ${contentType}`);
+  lines.push('');
+  lines.push(options.body);
+  return lines.join('\r\n');
+}
 
 export default class SmtpService {
   constructor(
@@ -36,14 +72,29 @@ export default class SmtpService {
     const account = this.connections.getAccount(accountName);
     const transport = await this.connections.getSmtpTransport(accountName);
 
-    const result = await transport.sendMail({
+    const mailOptions = {
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to: options.to.join(', '),
       cc: options.cc?.join(', '),
       bcc: options.bcc?.join(', '),
       subject: options.subject,
       ...(options.html ? { html: options.body } : { text: options.body }),
-    });
+    };
+
+    const result = await transport.sendMail(mailOptions);
+
+    await this.appendToSentFolder(
+      accountName,
+      buildRawMessage({
+        from: mailOptions.from,
+        to: mailOptions.to,
+        subject: mailOptions.subject,
+        body: options.body,
+        cc: mailOptions.cc,
+        messageId: result.messageId ?? '',
+        html: options.html,
+      }),
+    );
 
     return {
       messageId: result.messageId ?? '',
@@ -98,8 +149,10 @@ export default class SmtpService {
 
     const transport = await this.connections.getSmtpTransport(accountName);
 
+    const fromAddr = account.fullName ? `"${account.fullName}" <${account.email}>` : account.email;
+
     const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
+      from: fromAddr,
       to: to.join(', '),
       cc: cc.length > 0 ? cc.join(', ') : undefined,
       subject,
@@ -107,6 +160,21 @@ export default class SmtpService {
       references: references.join(' '),
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
+
+    await this.appendToSentFolder(
+      accountName,
+      buildRawMessage({
+        from: fromAddr,
+        to: to.join(', '),
+        subject,
+        body: options.body,
+        cc: cc.length > 0 ? cc.join(', ') : undefined,
+        messageId: result.messageId ?? '',
+        inReplyTo: original.messageId,
+        references: references.join(' '),
+        html: options.html,
+      }),
+    );
 
     return {
       messageId: result.messageId ?? '',
@@ -153,13 +221,27 @@ export default class SmtpService {
 
     const transport = await this.connections.getSmtpTransport(accountName);
 
+    const fromAddr = account.fullName ? `"${account.fullName}" <${account.email}>` : account.email;
+
     const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
+      from: fromAddr,
       to: options.to.join(', '),
       cc: options.cc?.join(', '),
       subject,
       text: fullBody,
     });
+
+    await this.appendToSentFolder(
+      accountName,
+      buildRawMessage({
+        from: fromAddr,
+        to: options.to.join(', '),
+        subject,
+        body: fullBody,
+        cc: options.cc?.join(', '),
+        messageId: result.messageId ?? '',
+      }),
+    );
 
     return {
       messageId: result.messageId ?? '',
@@ -177,6 +259,31 @@ export default class SmtpService {
         `Rate limit exceeded for account "${accountName}". ` +
           `Please wait before sending more emails.`,
       );
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Sent folder helpers
+  // -------------------------------------------------------------------------
+
+  private async appendToSentFolder(
+    accountName: string,
+    rawMessage: string | Buffer,
+  ): Promise<void> {
+    const account = this.connections.getAccount(accountName);
+
+    // Skip if disabled in config
+    if (account.saveToSent === false) return;
+
+    // Skip Gmail (auto-saves via SMTP)
+    if (isGmailAccount(account) && account.gmailAutoSave !== false) return;
+
+    try {
+      await this.imapService.appendToSent(accountName, rawMessage);
+    } catch (error) {
+      // Log warning but do not throw — SMTP send already succeeded
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to save to Sent folder for ${accountName}:`, error);
     }
   }
 
@@ -199,9 +306,10 @@ export default class SmtpService {
 
     const to = draft.to.map((a) => a.address).join(', ');
     const cc = draft.cc?.map((a) => a.address).join(', ');
+    const fromAddr = account.fullName ? `"${account.fullName}" <${account.email}>` : account.email;
 
     const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
+      from: fromAddr,
       to,
       cc,
       subject: draft.subject,
@@ -209,6 +317,22 @@ export default class SmtpService {
       references: draft.references?.join(' '),
       ...(draft.bodyHtml ? { html: draft.bodyHtml } : { text: draft.bodyText ?? '' }),
     });
+
+    // Append to Sent BEFORE deleting the draft
+    await this.appendToSentFolder(
+      accountName,
+      buildRawMessage({
+        from: fromAddr,
+        to,
+        subject: draft.subject,
+        body: draft.bodyHtml ?? draft.bodyText ?? '',
+        cc,
+        messageId: result.messageId ?? '',
+        inReplyTo: draft.inReplyTo,
+        references: draft.references?.join(' '),
+        html: !!draft.bodyHtml,
+      }),
+    );
 
     // Delete the draft after successful send
     await this.imapService.deleteDraft(accountName, draftId, draftsPath);

--- a/src/tools/attachments.tool.ts
+++ b/src/tools/attachments.tool.ts
@@ -1,13 +1,29 @@
 /**
- * MCP tool: download_attachment
+ * MCP tools: download_attachment, save_attachment, save_all_attachments_from_search.
+ *
+ * `download_attachment` returns base64 through the MCP response (legacy — 5 MB
+ * ceiling, ~25k token cap). The two new tools bypass that and write directly
+ * to disk under `$HOME` or `/tmp`.
  */
+
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
+import type ConnectionManager from '../connections/manager.js';
 import type ImapService from '../services/imap.service.js';
 
-export default function registerAttachmentTools(server: McpServer, imapService: ImapService): void {
+export default function registerAttachmentTools(
+  server: McpServer,
+  imapService: ImapService,
+  connections: ConnectionManager,
+): void {
+  // ---------------------------------------------------------------------------
+  // download_attachment (legacy — base64 through MCP response)
+  // ---------------------------------------------------------------------------
   server.tool(
     'download_attachment',
     'Download an email attachment by filename. First use get_email to see available attachments and their filenames. Returns base64-encoded content for files ≤5MB.',
@@ -50,6 +66,249 @@ export default function registerAttachmentTools(server: McpServer, imapService: 
             {
               type: 'text' as const,
               text: `Failed to download attachment: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // save_attachment — direct-to-disk, no base64 hop
+  // ---------------------------------------------------------------------------
+  server.tool(
+    'save_attachment',
+    'Save an email attachment directly to disk. Unlike download_attachment (which returns base64), ' +
+      'this writes the file to your filesystem without size limits and without streaming bytes through ' +
+      'the MCP response. Default destination is ~/Downloads/<filename>.',
+    {
+      account: z.string().describe('Account name from list_accounts'),
+      emailId: z.string().describe('Email ID (UID) from list_emails or get_email'),
+      mailbox: z.string().default('INBOX').describe('Mailbox containing the email'),
+      filename: z.string().describe('Exact attachment filename from get_email metadata'),
+      destination: z
+        .string()
+        .optional()
+        .describe(
+          'Absolute path OR directory. If directory, the attachment keeps its original filename. ' +
+            'Default: ~/Downloads/',
+        ),
+      open: z
+        .boolean()
+        .default(false)
+        .describe('Open the file in the default macOS application after save'),
+      overwrite: z
+        .boolean()
+        .default(false)
+        .describe(
+          'Allow overwriting an existing file; otherwise auto-suffix (file-1.pdf, file-2.pdf)',
+        ),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async ({ account, emailId, mailbox, filename, destination, open, overwrite }) => {
+      try {
+        const target = destination ?? join(homedir(), 'Downloads');
+        const result = await imapService.saveAttachmentToDisk(
+          account,
+          emailId,
+          mailbox,
+          filename,
+          target,
+          overwrite,
+        );
+
+        if (open && process.platform === 'darwin') {
+          try {
+            const child = spawn('open', [result.path], {
+              detached: true,
+              stdio: 'ignore',
+            });
+            child.unref();
+          } catch {
+            // Non-fatal — file was saved, we just couldn't open it.
+          }
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  path: result.path,
+                  size: result.size,
+                  sizeHuman: `${Math.round(result.size / 1024)}KB`,
+                  mimeType: result.mimeType,
+                  opened: open && process.platform === 'darwin',
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to save attachment: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // save_all_attachments_from_search — batch sweep
+  // ---------------------------------------------------------------------------
+  server.tool(
+    'save_all_attachments_from_search',
+    'Run a search and download every attachment (optionally filtered by filename/mimetype) into a ' +
+      'dated folder under ~/Downloads/. Useful for audit exports, year-end lease PDF sweeps, vendor ' +
+      'invoice collections.',
+    {
+      account: z
+        .string()
+        .optional()
+        .describe('Single-account mode; mutually exclusive with accounts'),
+      accounts: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Cross-account fan-out; defaults to all accounts when neither account nor accounts is set',
+        ),
+      mailbox: z.string().default('INBOX'),
+      query: z.string().optional().default(''),
+      to: z.string().optional(),
+      from: z.string().optional(),
+      subject: z.string().optional(),
+      cc: z.string().optional(),
+      bcc: z.string().optional(),
+      text: z.string().optional(),
+      body: z.string().optional(),
+      since: z.string().optional(),
+      before: z.string().optional(),
+      on: z.string().optional(),
+      sent_since: z.string().optional(),
+      sent_before: z.string().optional(),
+      seen: z.boolean().optional(),
+      flagged: z.boolean().optional(),
+      has_attachment: z.boolean().optional(),
+      larger_than: z.number().optional(),
+      smaller_than: z.number().optional(),
+      answered: z.boolean().optional(),
+      draft: z.boolean().optional(),
+      deleted: z.boolean().optional(),
+      keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      header: z.record(z.string(), z.string()).optional(),
+      gmail_raw: z.string().optional(),
+      attachment_filename: z
+        .string()
+        .optional()
+        .describe('Only save attachments whose filename matches this substring (case-insensitive)'),
+      attachment_mimetype: z
+        .string()
+        .optional()
+        .describe('Only save attachments whose MIME type matches this regex'),
+      max_emails: z.number().int().min(1).max(10000).default(1000),
+      destination: z
+        .string()
+        .optional()
+        .describe('Destination folder. Default: ~/Downloads/email-attachments-<ts>/'),
+      organize_by: z
+        .enum(['flat', 'date', 'sender', 'account'])
+        .default('flat')
+        .describe('Subfolder structure under destination'),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => {
+      try {
+        // Default destination — dated subfolder under ~/Downloads.
+        const tsSlug = new Date().toISOString().replace(/[:.]/g, '-');
+        const folder =
+          params.destination ?? join(homedir(), 'Downloads', `email-attachments-${tsSlug}`);
+
+        // Resolve account mode
+        let accountNames: string[] | null = null;
+        let accountName: string | null = null;
+        if (params.account) {
+          accountName = params.account;
+        } else if (params.accounts && params.accounts.length > 0) {
+          accountNames = params.accounts;
+        } else {
+          accountNames = connections.getAccountNames();
+        }
+
+        const searchOptions = {
+          mailbox: params.mailbox,
+          to: params.to,
+          from: params.from,
+          subject: params.subject,
+          cc: params.cc,
+          bcc: params.bcc,
+          text: params.text,
+          body: params.body,
+          since: params.since,
+          before: params.before,
+          on: params.on,
+          sentSince: params.sent_since,
+          sentBefore: params.sent_before,
+          seen: params.seen,
+          flagged: params.flagged,
+          answered: params.answered,
+          draft: params.draft,
+          deleted: params.deleted,
+          keyword: params.keyword,
+          notKeyword: params.not_keyword,
+          header: params.header,
+          hasAttachment: params.has_attachment,
+          largerThan: params.larger_than,
+          smallerThan: params.smaller_than,
+          gmailRaw: params.gmail_raw,
+        };
+
+        const result = await imapService.saveAllAttachmentsFromSearch({
+          accountNames,
+          accountName,
+          query: params.query ?? '',
+          searchOptions,
+          maxEmails: params.max_emails,
+          destinationFolder: folder,
+          organizeBy: params.organize_by,
+          attachmentFilename: params.attachment_filename,
+          attachmentMimetype: params.attachment_mimetype,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  folder: result.folder,
+                  files_saved: result.files_saved,
+                  total_size: result.total_size,
+                  total_size_human: `${(result.total_size / 1024 / 1024).toFixed(2)}MB`,
+                  skipped: result.skipped,
+                  errors: result.errors,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to save attachments: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -31,7 +31,15 @@ function formatEmailMeta(email: EmailMeta): string {
   const from = email.from.name ? `${email.from.name} <${email.from.address}>` : email.from.address;
   const labelStr = email.labels.length > 0 ? `\n  🏷️ ${email.labels.join(', ')}` : '';
 
-  return `[${email.id}] ${flags} ${email.subject}\n  From: ${from} | ${email.date}${labelStr}${email.preview ? `\n  ${email.preview}` : ''}`;
+  let attachLine = '';
+  if (email.attachments && email.attachments.length > 0) {
+    const names = email.attachments.map((a) => a.filename);
+    const shown = names.slice(0, 3).join(', ');
+    const extra = names.length > 3 ? ` (+${names.length - 3} more)` : '';
+    attachLine = `\n  📎 Attachments: ${shown}${extra}`;
+  }
+
+  return `[${email.id}] ${flags} ${email.subject}\n  From: ${from} | ${email.date}${labelStr}${attachLine}${email.preview ? `\n  ${email.preview}` : ''}`;
 }
 
 /** Strips HTML markup and decodes common entities to produce readable plain text. */
@@ -174,6 +182,18 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .describe('Specific UID ranges (array of numbers or IMAP sequence string like "1:100")'),
       larger_than: z.number().optional().describe('Minimum email size in KB'),
       smaller_than: z.number().optional().describe('Maximum email size in KB'),
+      attachment_filename: z
+        .string()
+        .optional()
+        .describe(
+          'Filter by attachment filename substring (case-insensitive). Example: "lease" matches "signed_lease_v7.pdf".',
+        ),
+      attachment_mimetype: z
+        .string()
+        .optional()
+        .describe(
+          'Filter by MIME type regex (case-insensitive). Examples: "application/pdf", "image/.*".',
+        ),
       gmail_raw: z
         .string()
         .optional()
@@ -212,6 +232,8 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           uids: params.uids,
           largerThan: params.larger_than,
           smallerThan: params.smaller_than,
+          attachmentFilename: params.attachment_filename,
+          attachmentMimetype: params.attachment_mimetype,
           gmailRaw: params.gmail_raw,
         });
 
@@ -554,6 +576,25 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .union([z.array(z.number()), z.string()])
         .optional()
         .describe('Specific UID ranges (array of numbers or IMAP sequence string like "1:100")'),
+      attachment_filename: z
+        .string()
+        .optional()
+        .describe(
+          'Filter by attachment filename substring (case-insensitive). Example: "lease" matches "signed_lease_v7.pdf".',
+        ),
+      attachment_mimetype: z
+        .string()
+        .optional()
+        .describe(
+          'Filter by MIME type regex (case-insensitive). Examples: "application/pdf", "image/.*".',
+        ),
+      facets: z
+        .array(z.enum(['sender', 'year', 'mailbox']))
+        .optional()
+        .describe(
+          'Return bucketed counts by sender/year/mailbox alongside the paginated results. ' +
+            'Useful for understanding large result sets. Skipped if match set exceeds 10000 UIDs.',
+        ),
       gmail_raw: z
         .string()
         .optional()
@@ -592,6 +633,9 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           notKeyword: params.not_keyword,
           header: params.header,
           uids: params.uids,
+          attachmentFilename: params.attachment_filename,
+          attachmentMimetype: params.attachment_mimetype,
+          facets: params.facets,
           gmailRaw: params.gmail_raw,
         });
 
@@ -619,11 +663,38 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           `(page ${result.page}/${Math.ceil(result.total / result.pageSize)})\n`;
         const emails = result.items.map(formatEmailMeta).join('\n\n');
 
+        let facetsBlock = '';
+        if (result.facets) {
+          const lines: string[] = ['', '📊 Facets'];
+          if (result.facets.sender) {
+            const top = Object.entries(result.facets.sender)
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, 10)
+              .map(([k, v]) => `${k} (${v})`)
+              .join(', ');
+            lines.push(`  By sender: ${top || '(none)'}`);
+          }
+          if (result.facets.year) {
+            const all = Object.entries(result.facets.year)
+              .sort((a, b) => b[0].localeCompare(a[0]))
+              .map(([k, v]) => `${k} (${v})`)
+              .join(', ');
+            lines.push(`  By year:   ${all || '(none)'}`);
+          }
+          if (result.facets.mailbox) {
+            const all = Object.entries(result.facets.mailbox)
+              .map(([k, v]) => `${k} (${v})`)
+              .join(', ');
+            lines.push(`  By mailbox: ${all || '(none)'}`);
+          }
+          facetsBlock = `\n${lines.join('\n')}`;
+        }
+
         return {
           content: [
             {
               type: 'text' as const,
-              text: `${warningPrefix}${header}\n${emails}`,
+              text: `${warningPrefix}${header}\n${emails}${facetsBlock}`,
             },
           ],
         };

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -98,11 +98,32 @@ export function formatSearchResult(
 
   let accountWarningsBlock = '';
   if (result.warnings && result.warnings.length > 0) {
-    const lines = ['', '⚠️ Warnings'];
-    result.warnings.forEach((w) => {
-      lines.push(`  - ${w.account}: ${w.error}`);
-    });
-    accountWarningsBlock = `\n${lines.join('\n')}`;
+    // Split warnings into "informational remaps" (ℹ️-prefixed message) vs
+    // hard errors/skips. Both live in the same warnings[] array for backward
+    // compat; we classify here purely for rendering.
+    const infos = result.warnings.filter((w) => w.error.startsWith('ℹ️'));
+    const hard = result.warnings.filter((w) => !w.error.startsWith('ℹ️'));
+    const blocks: string[] = [];
+    if (hard.length > 0) {
+      const lines = [`⚠️ Warnings (${hard.length} account${hard.length === 1 ? '' : 's'})`];
+      hard.forEach((w) => {
+        lines.push(`  - ${w.account}: ${w.error}`);
+      });
+      blocks.push(lines.join('\n'));
+    }
+    if (infos.length > 0) {
+      const lines = [`ℹ️ Remapped (${infos.length} account${infos.length === 1 ? '' : 's'})`];
+      infos.forEach((w) => {
+        // Strip the leading emoji + space since the section header already
+        // carries one — avoid double-ℹ️ in rendered output.
+        const msg = w.error.replace(/^ℹ️\s*/, '');
+        lines.push(`  - ${w.account}: ${msg}`);
+      });
+      blocks.push(lines.join('\n'));
+    }
+    if (blocks.length > 0) {
+      accountWarningsBlock = `\n\n${blocks.join('\n\n')}`;
+    }
   }
 
   return `${warningPrefix}${header}\n${emails}${facetsBlock}${accountWarningsBlock}`;

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -1,12 +1,14 @@
 /**
- * MCP tools: list_emails, get_email, get_emails, get_email_status, search_emails
+ * MCP tools: list_emails, get_email, get_emails, get_email_status,
+ * search_emails, search_all_accounts.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
+import type ConnectionManager from '../connections/manager.js';
 import type ImapService from '../services/imap.service.js';
-import type { Email, EmailMeta } from '../types/index.js';
+import type { Email, EmailMeta, FacetResult, PaginatedResult } from '../types/index.js';
 
 // ---------------------------------------------------------------------------
 // Formatting helpers
@@ -39,7 +41,71 @@ function formatEmailMeta(email: EmailMeta): string {
     attachLine = `\n  📎 Attachments: ${shown}${extra}`;
   }
 
-  return `[${email.id}] ${flags} ${email.subject}\n  From: ${from} | ${email.date}${labelStr}${attachLine}${email.preview ? `\n  ${email.preview}` : ''}`;
+  const accountTag = email.account ? `[${email.account}] ` : '';
+  return `${accountTag}[${email.id}] ${flags} ${email.subject}\n  From: ${from} | ${email.date}${labelStr}${attachLine}${email.preview ? `\n  ${email.preview}` : ''}`;
+}
+
+/**
+ * Render a facet result block (sender/year/mailbox) — shared between
+ * `search_emails`, `search_all_accounts`, and `run_preset`.
+ */
+export function formatFacetsBlock(facets: FacetResult | undefined): string {
+  if (!facets) return '';
+  const lines: string[] = ['', '📊 Facets'];
+  if (facets.sender) {
+    const top = Object.entries(facets.sender)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([k, v]) => `${k} (${v})`)
+      .join(', ');
+    lines.push(`  By sender: ${top || '(none)'}`);
+  }
+  if (facets.year) {
+    const all = Object.entries(facets.year)
+      .sort((a, b) => b[0].localeCompare(a[0]))
+      .map(([k, v]) => `${k} (${v})`)
+      .join(', ');
+    lines.push(`  By year:   ${all || '(none)'}`);
+  }
+  if (facets.mailbox) {
+    const all = Object.entries(facets.mailbox)
+      .map(([k, v]) => `${k} (${v})`)
+      .join(', ');
+    lines.push(`  By mailbox: ${all || '(none)'}`);
+  }
+  return `\n${lines.join('\n')}`;
+}
+
+/**
+ * Format a paginated search result (single- or cross-account) for MCP text
+ * output. Used by `search_emails`, `search_all_accounts`, and `run_preset`.
+ */
+export function formatSearchResult(
+  result: PaginatedResult<EmailMeta> & {
+    warnings?: { account: string; error: string }[];
+  },
+  header: string,
+  emptyMessage: string,
+): string {
+  const warningPrefix = result.warning ? `⚠️ ${result.warning}\n` : '';
+
+  if (result.items.length === 0) {
+    return `${warningPrefix}${emptyMessage}`;
+  }
+
+  const emails = result.items.map(formatEmailMeta).join('\n\n');
+  const facetsBlock = formatFacetsBlock(result.facets);
+
+  let accountWarningsBlock = '';
+  if (result.warnings && result.warnings.length > 0) {
+    const lines = ['', '⚠️ Warnings'];
+    result.warnings.forEach((w) => {
+      lines.push(`  - ${w.account}: ${w.error}`);
+    });
+    accountWarningsBlock = `\n${lines.join('\n')}`;
+  }
+
+  return `${warningPrefix}${header}\n${emails}${facetsBlock}${accountWarningsBlock}`;
 }
 
 /** Strips HTML markup and decodes common entities to produce readable plain text. */
@@ -117,7 +183,11 @@ function formatEmailStatus(email: Pick<Email, 'seen' | 'flagged' | 'answered' | 
 
 // ---------------------------------------------------------------------------
 
-export default function registerEmailsTools(server: McpServer, imapService: ImapService): void {
+export default function registerEmailsTools(
+  server: McpServer,
+  imapService: ImapService,
+  connections: ConnectionManager,
+): void {
   // ---------------------------------------------------------------------------
   // list_emails
   // ---------------------------------------------------------------------------
@@ -639,62 +709,21 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           gmailRaw: params.gmail_raw,
         });
 
-        const warningPrefix = result.warning ? `⚠️ ${result.warning}\n` : '';
-
-        if (result.items.length === 0) {
-          return {
-            content: [
-              {
-                type: 'text' as const,
-                text:
-                  warningPrefix +
-                  (params.query
-                    ? `No emails found matching "${params.query}".`
-                    : 'No emails found matching the specified filters.'),
-              },
-            ],
-          };
-        }
-
         const totalDisplay = result.totalApprox ? `~${result.total}` : `${result.total}`;
         const queryLabel = params.query ? `"${params.query}"` : 'filters';
+        const totalPages = result.total > 0 ? Math.ceil(result.total / result.pageSize) : 1;
         const header =
           `🔍 [${params.mailbox}] ${totalDisplay} result(s) for ${queryLabel} ` +
-          `(page ${result.page}/${Math.ceil(result.total / result.pageSize)})\n`;
-        const emails = result.items.map(formatEmailMeta).join('\n\n');
-
-        let facetsBlock = '';
-        if (result.facets) {
-          const lines: string[] = ['', '📊 Facets'];
-          if (result.facets.sender) {
-            const top = Object.entries(result.facets.sender)
-              .sort((a, b) => b[1] - a[1])
-              .slice(0, 10)
-              .map(([k, v]) => `${k} (${v})`)
-              .join(', ');
-            lines.push(`  By sender: ${top || '(none)'}`);
-          }
-          if (result.facets.year) {
-            const all = Object.entries(result.facets.year)
-              .sort((a, b) => b[0].localeCompare(a[0]))
-              .map(([k, v]) => `${k} (${v})`)
-              .join(', ');
-            lines.push(`  By year:   ${all || '(none)'}`);
-          }
-          if (result.facets.mailbox) {
-            const all = Object.entries(result.facets.mailbox)
-              .map(([k, v]) => `${k} (${v})`)
-              .join(', ');
-            lines.push(`  By mailbox: ${all || '(none)'}`);
-          }
-          facetsBlock = `\n${lines.join('\n')}`;
-        }
+          `(page ${result.page}/${totalPages})\n`;
+        const emptyMsg = params.query
+          ? `No emails found matching "${params.query}".`
+          : 'No emails found matching the specified filters.';
 
         return {
           content: [
             {
               type: 'text' as const,
-              text: `${warningPrefix}${header}\n${emails}${facetsBlock}`,
+              text: formatSearchResult(result, header, emptyMsg),
             },
           ],
         };
@@ -705,6 +734,154 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
             {
               type: 'text' as const,
               text: `Failed to search emails: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // search_all_accounts
+  // ---------------------------------------------------------------------------
+  server.tool(
+    'search_all_accounts',
+    'Search emails across multiple accounts in parallel. Same filter set as search_emails ' +
+      'but fans out across N accounts and merges results sorted by date. Each result is tagged ' +
+      'with the account it came from. Partial failures are surfaced as warnings without failing ' +
+      'the whole call. Useful for "find X anywhere in my inboxes" queries across your email ecosystem.',
+    {
+      query: z
+        .string()
+        .optional()
+        .default('')
+        .describe('Search keyword across subject/from/body (omit to use filters only)'),
+      accounts: z
+        .array(z.string())
+        .optional()
+        .describe('Specific accounts to search (default: all accounts from list_accounts)'),
+      mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
+      page: z.number().int().min(1).default(1).describe('Page number of the merged result set'),
+      pageSize: z
+        .number()
+        .int()
+        .min(1)
+        .max(100)
+        .default(20)
+        .describe('Results per page (merged across accounts)'),
+      to: z.string().optional(),
+      from: z.string().optional(),
+      subject: z.string().optional(),
+      cc: z.string().optional(),
+      bcc: z.string().optional(),
+      text: z.string().optional(),
+      body: z.string().optional(),
+      since: z.string().optional(),
+      before: z.string().optional(),
+      on: z.string().optional(),
+      sent_since: z.string().optional(),
+      sent_before: z.string().optional(),
+      seen: z.boolean().optional(),
+      flagged: z.boolean().optional(),
+      has_attachment: z.boolean().optional(),
+      larger_than: z.number().optional(),
+      smaller_than: z.number().optional(),
+      answered: z.boolean().optional(),
+      draft: z.boolean().optional(),
+      deleted: z.boolean().optional(),
+      keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      header: z.record(z.string(), z.string()).optional(),
+      attachment_filename: z.string().optional(),
+      attachment_mimetype: z.string().optional(),
+      facets: z.array(z.enum(['sender', 'year', 'mailbox'])).optional(),
+      gmail_raw: z
+        .string()
+        .optional()
+        .describe(
+          'Gmail accounts ONLY (when targeted accounts include Gmail). Non-Gmail accounts in the ' +
+            'fan-out will error individually and appear in warnings.',
+        ),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => {
+      try {
+        const accountNames =
+          params.accounts && params.accounts.length > 0
+            ? params.accounts
+            : connections.getAccountNames();
+
+        if (accountNames.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No accounts configured — add at least one account to config.toml.',
+              },
+            ],
+          };
+        }
+
+        const result = await imapService.searchAcrossAccounts(accountNames, params.query ?? '', {
+          mailbox: params.mailbox,
+          page: params.page,
+          pageSize: params.pageSize,
+          to: params.to,
+          from: params.from,
+          subject: params.subject,
+          cc: params.cc,
+          bcc: params.bcc,
+          text: params.text,
+          body: params.body,
+          since: params.since,
+          before: params.before,
+          on: params.on,
+          sentSince: params.sent_since,
+          sentBefore: params.sent_before,
+          seen: params.seen,
+          flagged: params.flagged,
+          hasAttachment: params.has_attachment,
+          largerThan: params.larger_than,
+          smallerThan: params.smaller_than,
+          answered: params.answered,
+          draft: params.draft,
+          deleted: params.deleted,
+          keyword: params.keyword,
+          notKeyword: params.not_keyword,
+          header: params.header,
+          attachmentFilename: params.attachment_filename,
+          attachmentMimetype: params.attachment_mimetype,
+          facets: params.facets,
+          gmailRaw: params.gmail_raw,
+        });
+
+        const totalDisplay = result.totalApprox ? `~${result.total}` : `${result.total}`;
+        const queryLabel = params.query ? `"${params.query}"` : 'filters';
+        const totalPages = result.total > 0 ? Math.ceil(result.total / result.pageSize) : 1;
+        const header =
+          `🔍 [${accountNames.length} account(s) · ${params.mailbox}] ` +
+          `${totalDisplay} result(s) for ${queryLabel} ` +
+          `(page ${result.page}/${totalPages})\n`;
+        const emptyMsg = params.query
+          ? `No emails found matching "${params.query}" across ${accountNames.length} account(s).`
+          : `No emails found matching the specified filters across ${accountNames.length} account(s).`;
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: formatSearchResult(result, header, emptyMsg),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to search accounts: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -115,8 +115,11 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
   // ---------------------------------------------------------------------------
   server.tool(
     'list_emails',
-    'List emails in a mailbox with optional filters. Returns paginated results with metadata ' +
-      '(read/unread 🔵, flagged ⭐, replied ↩️, attachments 📎, labels 🏷️). ' +
+    'List emails with optional server-side filters. Supports date ranges (since/before/on, ' +
+      'including relative tokens like "7d", "yesterday"), subject/from/to/cc/bcc/body/text search, ' +
+      'read/flag/answered state, keywords/labels, header matches, and UID ranges. ' +
+      'On Gmail accounts, pass gmail_raw for native Gmail search syntax (dramatically faster). ' +
+      'Returns paginated metadata (read/unread 🔵, flagged ⭐, replied ↩️, attachments 📎, labels 🏷️). ' +
       'Use get_email to fetch full body content. ' +
       'ProtonMail note: labels are represented as IMAP folders — use list_labels to discover them, ' +
       'then list_emails with mailbox="Labels/X" to find labeled emails.',
@@ -125,17 +128,58 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
       page: z.number().int().min(1).default(1).describe('Page number'),
       pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
-      since: z.string().optional().describe('Show emails after this date (ISO 8601)'),
-      before: z.string().optional().describe('Show emails before this date (ISO 8601)'),
+      since: z
+        .string()
+        .optional()
+        .describe(
+          'Date filter: received on/after. Accepts ISO 8601, YYYY-MM-DD, or relative like "7d" / "yesterday"',
+        ),
+      before: z.string().optional().describe('Date filter: received strictly before'),
+      on: z.string().optional().describe('Date filter: received on specific date'),
+      sent_since: z
+        .string()
+        .optional()
+        .describe(
+          'Date header: sent on/after (differs from since which uses internal delivery date)',
+        ),
+      sent_before: z.string().optional().describe('Date header: sent before'),
       from: z.string().optional().describe('Filter by sender address or name'),
-      subject: z.string().optional().describe('Filter by subject keyword'),
-      seen: z.boolean().optional().describe('Filter: true=read only, false=unread only'),
-      flagged: z.boolean().optional().describe('Filter: true=flagged only, false=unflagged only'),
+      subject: z.string().optional().describe('Substring in Subject'),
+      to: z.string().optional().describe('Substring in To'),
+      cc: z.string().optional().describe('Substring in Cc'),
+      bcc: z.string().optional().describe('Substring in Bcc'),
+      text: z.string().optional().describe('Any text field (headers + body)'),
+      body: z.string().optional().describe('Body only'),
+      seen: z.boolean().optional().describe('true = read only; false = unread only'),
+      flagged: z.boolean().optional().describe('true = flagged; false = unflagged'),
       has_attachment: z
         .boolean()
         .optional()
         .describe('Filter: true=has attachments, false=no attachments'),
       answered: z.boolean().optional().describe('Filter: true=replied, false=not yet replied'),
+      draft: z.boolean().optional(),
+      deleted: z.boolean().optional(),
+      keyword: z
+        .union([z.string(), z.array(z.string())])
+        .optional()
+        .describe('IMAP keyword/label (AND when array)'),
+      not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      header: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe('Arbitrary header name/value match, e.g. {"X-Custom": "value"}'),
+      uids: z
+        .union([z.array(z.number()), z.string()])
+        .optional()
+        .describe('Specific UID ranges (array of numbers or IMAP sequence string like "1:100")'),
+      larger_than: z.number().optional().describe('Minimum email size in KB'),
+      smaller_than: z.number().optional().describe('Maximum email size in KB'),
+      gmail_raw: z
+        .string()
+        .optional()
+        .describe(
+          "Gmail accounts ONLY: pass Gmail search syntax (e.g. 'from:foo has:attachment') for dramatically faster server-side search. Other filters ignored when set.",
+        ),
     },
     { readOnlyHint: true, destructiveHint: false },
     async (params) => {
@@ -146,28 +190,58 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           pageSize: params.pageSize,
           since: params.since,
           before: params.before,
+          on: params.on,
+          sentSince: params.sent_since,
+          sentBefore: params.sent_before,
           from: params.from,
           subject: params.subject,
+          to: params.to,
+          cc: params.cc,
+          bcc: params.bcc,
+          text: params.text,
+          body: params.body,
           seen: params.seen,
           flagged: params.flagged,
           hasAttachment: params.has_attachment,
           answered: params.answered,
+          draft: params.draft,
+          deleted: params.deleted,
+          keyword: params.keyword,
+          notKeyword: params.not_keyword,
+          header: params.header,
+          uids: params.uids,
+          largerThan: params.larger_than,
+          smallerThan: params.smaller_than,
+          gmailRaw: params.gmail_raw,
         });
+
+        const warningPrefix = result.warning ? `⚠️ ${result.warning}\n` : '';
 
         if (result.items.length === 0) {
           return {
-            content: [{ type: 'text' as const, text: 'No emails found matching the criteria.' }],
+            content: [
+              {
+                type: 'text' as const,
+                text: `${warningPrefix}No emails found matching the criteria.`,
+              },
+            ],
           };
         }
 
+        const totalDisplay = result.totalApprox ? `~${result.total}` : `${result.total}`;
         const header =
-          `📬 [${params.mailbox}] ${result.total} emails ` +
+          `📬 [${params.mailbox}] ${totalDisplay} emails ` +
           `(page ${result.page}/${Math.ceil(result.total / result.pageSize)})` +
           `${result.hasMore ? ' — more pages available' : ''}\n`;
         const emails = result.items.map(formatEmailMeta).join('\n\n');
 
         return {
-          content: [{ type: 'text' as const, text: `${header}\n${emails}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `${warningPrefix}${header}\n${emails}`,
+            },
+          ],
         };
       } catch (err) {
         return {
@@ -419,21 +493,45 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
   // ---------------------------------------------------------------------------
   server.tool(
     'search_emails',
-    'Search emails by keyword across subject, sender, and body. ' +
-      'Omit query (or pass an empty string) to use it as a pure filter — e.g. find all emails ' +
-      'with attachments from a specific recipient without a keyword. ' +
-      'Supports additional filters for recipient, attachments, size, and reply status.',
+    'Search emails with server-side filters. Omit query (or pass an empty string) to use pure filters. ' +
+      'Supports date ranges (since/before/on, including "7d" / "yesterday"), subject/from/to/cc/bcc/body/text ' +
+      'filters, read/flag/answered state, keywords/labels, header matches, UID ranges, size limits, and attachments. ' +
+      "On Gmail accounts, pass gmail_raw (e.g. 'from:foo has:attachment older_than:30d') for a dramatically " +
+      'faster native Gmail search. Results are paginated; large result sets are capped at 5000 UIDs with a warning.',
     {
       account: z.string().describe('Account name from list_accounts'),
       query: z
         .string()
         .optional()
         .default('')
-        .describe('Search keyword (omit or leave empty to use filters only)'),
+        .describe('Search keyword across subject/from/body (omit to use filters only)'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
       page: z.number().int().min(1).default(1).describe('Page number'),
       pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
       to: z.string().optional().describe('Filter by recipient address'),
+      from: z.string().optional().describe('Filter by sender address or name'),
+      subject: z.string().optional().describe('Substring in Subject'),
+      cc: z.string().optional().describe('Substring in Cc'),
+      bcc: z.string().optional().describe('Substring in Bcc'),
+      text: z.string().optional().describe('Any text field (headers + body)'),
+      body: z.string().optional().describe('Body only'),
+      since: z
+        .string()
+        .optional()
+        .describe(
+          'Date filter: received on/after. Accepts ISO 8601, YYYY-MM-DD, or relative like "7d" / "yesterday"',
+        ),
+      before: z.string().optional().describe('Date filter: received strictly before'),
+      on: z.string().optional().describe('Date filter: received on specific date'),
+      sent_since: z
+        .string()
+        .optional()
+        .describe(
+          'Date header: sent on/after (differs from since which uses internal delivery date)',
+        ),
+      sent_before: z.string().optional().describe('Date header: sent before'),
+      seen: z.boolean().optional().describe('true = read only; false = unread only'),
+      flagged: z.boolean().optional().describe('true = flagged; false = unflagged'),
       has_attachment: z
         .boolean()
         .optional()
@@ -441,6 +539,27 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
       larger_than: z.number().optional().describe('Minimum email size in KB'),
       smaller_than: z.number().optional().describe('Maximum email size in KB'),
       answered: z.boolean().optional().describe('Filter: true=replied, false=not replied'),
+      draft: z.boolean().optional(),
+      deleted: z.boolean().optional(),
+      keyword: z
+        .union([z.string(), z.array(z.string())])
+        .optional()
+        .describe('IMAP keyword/label (AND when array)'),
+      not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      header: z
+        .record(z.string(), z.string())
+        .optional()
+        .describe('Arbitrary header name/value match, e.g. {"X-Custom": "value"}'),
+      uids: z
+        .union([z.array(z.number()), z.string()])
+        .optional()
+        .describe('Specific UID ranges (array of numbers or IMAP sequence string like "1:100")'),
+      gmail_raw: z
+        .string()
+        .optional()
+        .describe(
+          "Gmail accounts ONLY: pass Gmail search syntax (e.g. 'from:foo has:attachment') for dramatically faster server-side search. Other filters ignored when set.",
+        ),
     },
     { readOnlyHint: true, destructiveHint: false },
     async (params) => {
@@ -450,33 +569,63 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           page: params.page,
           pageSize: params.pageSize,
           to: params.to,
+          from: params.from,
+          subject: params.subject,
+          cc: params.cc,
+          bcc: params.bcc,
+          text: params.text,
+          body: params.body,
+          since: params.since,
+          before: params.before,
+          on: params.on,
+          sentSince: params.sent_since,
+          sentBefore: params.sent_before,
+          seen: params.seen,
+          flagged: params.flagged,
           hasAttachment: params.has_attachment,
           largerThan: params.larger_than,
           smallerThan: params.smaller_than,
           answered: params.answered,
+          draft: params.draft,
+          deleted: params.deleted,
+          keyword: params.keyword,
+          notKeyword: params.not_keyword,
+          header: params.header,
+          uids: params.uids,
+          gmailRaw: params.gmail_raw,
         });
+
+        const warningPrefix = result.warning ? `⚠️ ${result.warning}\n` : '';
 
         if (result.items.length === 0) {
           return {
             content: [
               {
                 type: 'text' as const,
-                text: params.query
-                  ? `No emails found matching "${params.query}".`
-                  : 'No emails found matching the specified filters.',
+                text:
+                  warningPrefix +
+                  (params.query
+                    ? `No emails found matching "${params.query}".`
+                    : 'No emails found matching the specified filters.'),
               },
             ],
           };
         }
 
+        const totalDisplay = result.totalApprox ? `~${result.total}` : `${result.total}`;
         const queryLabel = params.query ? `"${params.query}"` : 'filters';
         const header =
-          `🔍 [${params.mailbox}] ${result.total} result(s) for ${queryLabel} ` +
+          `🔍 [${params.mailbox}] ${totalDisplay} result(s) for ${queryLabel} ` +
           `(page ${result.page}/${Math.ceil(result.total / result.pageSize)})\n`;
         const emails = result.items.map(formatEmailMeta).join('\n\n');
 
         return {
-          content: [{ type: 'text' as const, text: `${header}\n${emails}` }],
+          content: [
+            {
+              type: 'text' as const,
+              text: `${warningPrefix}${header}\n${emails}`,
+            },
+          ],
         };
       } catch (err) {
         return {

--- a/src/tools/export.test.ts
+++ b/src/tools/export.test.ts
@@ -1,0 +1,172 @@
+/* eslint-disable n/no-sync -- tests use sync fs helpers for setup/teardown */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { EmailMeta } from '../types/index.js';
+import { writeExport } from './export.tool.js';
+
+function sampleEmail(partial: Partial<EmailMeta> = {}): EmailMeta {
+  return {
+    id: '1',
+    subject: 'Hello',
+    from: { name: 'Alice', address: 'alice@example.com' },
+    to: [{ address: 'bob@example.com' }],
+    date: '2024-03-15T12:00:00.000Z',
+    seen: true,
+    flagged: false,
+    answered: false,
+    hasAttachments: false,
+    labels: [],
+    preview: 'preview text',
+    attachments: [],
+    ...partial,
+  };
+}
+
+describe('writeExport', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'export-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a CSV with a header row and one data row per email (default columns)', async () => {
+    const dest = join(tmpDir, 'out.csv');
+    const items = [
+      sampleEmail({ id: '1', subject: 'Hello' }),
+      sampleEmail({ id: '2', subject: 'World' }),
+    ];
+    const columns = [
+      'id',
+      'account',
+      'date',
+      'from',
+      'subject',
+      'labels',
+      'attachments',
+      'has_attachments',
+      'seen',
+      'flagged',
+    ] as const;
+
+    const rows = await writeExport({
+      format: 'csv',
+      items,
+      columns: [...columns],
+      destination: dest,
+    });
+
+    expect(rows).toBe(2);
+    const content = readFileSync(dest, 'utf-8');
+    const lines = content.trim().split('\n');
+    expect(lines).toHaveLength(3); // header + 2 data rows
+    expect(lines[0]).toBe(
+      'id,account,date,from,subject,labels,attachments,has_attachments,seen,flagged',
+    );
+    expect(lines[1]).toBe(
+      '1,,2024-03-15T12:00:00.000Z,Alice <alice@example.com>,Hello,,,false,true,false',
+    );
+    expect(lines[2]).toBe(
+      '2,,2024-03-15T12:00:00.000Z,Alice <alice@example.com>,World,,,false,true,false',
+    );
+  });
+
+  it('honors a custom column selection (only chosen columns rendered)', async () => {
+    const dest = join(tmpDir, 'custom.csv');
+    const items = [sampleEmail({ id: '42', subject: 'Custom' })];
+
+    await writeExport({
+      format: 'csv',
+      items,
+      columns: ['id', 'subject'],
+      destination: dest,
+    });
+
+    const content = readFileSync(dest, 'utf-8').trim().split('\n');
+    expect(content[0]).toBe('id,subject');
+    expect(content[1]).toBe('42,Custom');
+  });
+
+  it('escapes CSV subject fields with commas and quotes', async () => {
+    const dest = join(tmpDir, 'escaped.csv');
+    const items = [sampleEmail({ id: '1', subject: 'Has "quotes", and commas' })];
+
+    await writeExport({ format: 'csv', items, columns: ['id', 'subject'], destination: dest });
+    const content = readFileSync(dest, 'utf-8').trim().split('\n');
+    expect(content[1]).toBe('1,"Has ""quotes"", and commas"');
+  });
+
+  it('writes NDJSON with one JSON object per line (full EmailMeta)', async () => {
+    const dest = join(tmpDir, 'out.ndjson');
+    const items = [sampleEmail({ id: '1', subject: 'A' }), sampleEmail({ id: '2', subject: 'B' })];
+
+    const rows = await writeExport({
+      format: 'ndjson',
+      items,
+      columns: [],
+      destination: dest,
+    });
+
+    expect(rows).toBe(2);
+    const content = readFileSync(dest, 'utf-8').trim().split('\n');
+    expect(content).toHaveLength(2);
+    const first = JSON.parse(content[0]) as EmailMeta;
+    const second = JSON.parse(content[1]) as EmailMeta;
+    expect(first.id).toBe('1');
+    expect(first.subject).toBe('A');
+    // Full EmailMeta is dumped — attachments and labels array are present
+    expect(Array.isArray(first.attachments)).toBe(true);
+    expect(second.id).toBe('2');
+  });
+
+  it('serializes attachments as pipe-delimited filenames in CSV', async () => {
+    const dest = join(tmpDir, 'att.csv');
+    const items = [
+      sampleEmail({
+        id: '1',
+        attachments: [
+          { filename: 'a.pdf', mimeType: 'application/pdf', size: 100 },
+          { filename: 'b.png', mimeType: 'image/png', size: 200 },
+        ],
+        hasAttachments: true,
+      }),
+    ];
+
+    await writeExport({
+      format: 'csv',
+      items,
+      columns: ['id', 'attachments', 'has_attachments'],
+      destination: dest,
+    });
+
+    const content = readFileSync(dest, 'utf-8').trim().split('\n');
+    expect(content[0]).toBe('id,attachments,has_attachments');
+    expect(content[1]).toBe('1,a.pdf|b.png,true');
+  });
+
+  it('handles zero items — CSV gets just a header, NDJSON is empty', async () => {
+    const csv = join(tmpDir, 'empty.csv');
+    await writeExport({ format: 'csv', items: [], columns: ['id', 'subject'], destination: csv });
+    expect(readFileSync(csv, 'utf-8')).toBe('id,subject\n');
+
+    const ndjson = join(tmpDir, 'empty.ndjson');
+    await writeExport({ format: 'ndjson', items: [], columns: [], destination: ndjson });
+    expect(readFileSync(ndjson, 'utf-8')).toBe('');
+  });
+
+  it('rowsWritten counts data rows only (excludes CSV header)', async () => {
+    const dest = join(tmpDir, 'count.csv');
+    const items = [sampleEmail({ id: '1' }), sampleEmail({ id: '2' }), sampleEmail({ id: '3' })];
+    const rows = await writeExport({
+      format: 'csv',
+      items,
+      columns: ['id'],
+      destination: dest,
+    });
+    expect(rows).toBe(3);
+  });
+});

--- a/src/tools/export.tool.ts
+++ b/src/tools/export.tool.ts
@@ -1,0 +1,321 @@
+/**
+ * MCP tool: export_search — run a search across one or many accounts and
+ * stream the result set to a CSV or NDJSON file under `~/Downloads/` (or an
+ * explicit destination).
+ *
+ * Bypasses the MCP response byte budget: the tool returns a tiny summary
+ * (path, rows_written, truncated) and the bulk of the data lives on disk.
+ */
+
+import { createWriteStream } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type ConnectionManager from '../connections/manager.js';
+import { toCsvRow } from '../services/csv.js';
+import { assertSafeDestination } from '../services/file-paths.js';
+import type ImapService from '../services/imap.service.js';
+import type { EmailMeta } from '../types/index.js';
+
+/** Column names understood for CSV output. */
+type CsvColumn =
+  | 'id'
+  | 'account'
+  | 'date'
+  | 'from'
+  | 'to'
+  | 'subject'
+  | 'flags'
+  | 'labels'
+  | 'attachments'
+  | 'preview'
+  | 'size';
+
+/** Default column ordering when `columns` is omitted. */
+const DEFAULT_CSV_COLUMNS = [
+  'id',
+  'account',
+  'date',
+  'from',
+  'subject',
+  'labels',
+  'attachments',
+  'has_attachments',
+  'seen',
+  'flagged',
+] as const;
+// Default set includes a few derived columns not in CSV_COLUMNS (has_attachments,
+// seen, flagged) — we widen the type below so they render correctly.
+type DefaultColumn = (typeof DEFAULT_CSV_COLUMNS)[number];
+
+function fromString(meta: EmailMeta): string {
+  const { from } = meta;
+  if (from.name && from.address) return `${from.name} <${from.address}>`;
+  return from.address;
+}
+
+function toFieldString(meta: EmailMeta): string {
+  return meta.to.map((t) => (t.name ? `${t.name} <${t.address}>` : t.address)).join(', ');
+}
+
+function flagsString(meta: EmailMeta): string {
+  const flags: string[] = [];
+  if (meta.seen) flags.push('seen');
+  if (meta.flagged) flags.push('flagged');
+  if (meta.answered) flags.push('answered');
+  return flags.join('|');
+}
+
+function attachmentsString(meta: EmailMeta): string {
+  return (meta.attachments ?? []).map((a) => a.filename).join('|');
+}
+
+function columnValue(meta: EmailMeta, col: CsvColumn | DefaultColumn): string {
+  switch (col) {
+    case 'id':
+      return meta.id;
+    case 'account':
+      return meta.account ?? '';
+    case 'date':
+      return meta.date;
+    case 'from':
+      return fromString(meta);
+    case 'to':
+      return toFieldString(meta);
+    case 'subject':
+      return meta.subject;
+    case 'flags':
+      return flagsString(meta);
+    case 'labels':
+      return meta.labels.join('|');
+    case 'attachments':
+      return attachmentsString(meta);
+    case 'preview':
+      return meta.preview ?? '';
+    case 'size':
+      // EmailMeta doesn't track size directly — fall back to summed attachment size
+      return String((meta.attachments ?? []).reduce((s, a) => s + a.size, 0));
+    case 'has_attachments':
+      return meta.hasAttachments ? 'true' : 'false';
+    case 'seen':
+      return meta.seen ? 'true' : 'false';
+    case 'flagged':
+      return meta.flagged ? 'true' : 'false';
+    default:
+      return '';
+  }
+}
+
+/**
+ * Write the export to disk. Exported for unit tests that want to exercise
+ * the writer without going through the full tool handler.
+ *
+ * Builds the serialized payload in-memory then streams it to disk. Memory
+ * pressure is bounded by `max_rows` (hard ceiling 50_000) × per-row size,
+ * well below any reasonable budget.
+ */
+export async function writeExport(params: {
+  format: 'csv' | 'ndjson';
+  items: EmailMeta[];
+  columns: (CsvColumn | DefaultColumn)[];
+  destination: string;
+}): Promise<number> {
+  let body: string;
+  let rowsWritten: number;
+
+  if (params.format === 'csv') {
+    const header = toCsvRow([...params.columns]);
+    const dataRows = params.items.map((item) => {
+      const row = params.columns.map((c) => columnValue(item, c));
+      return toCsvRow(row);
+    });
+    body = `${[header, ...dataRows].join('\n')}\n`;
+    rowsWritten = dataRows.length;
+  } else {
+    const lines = params.items.map((item) => JSON.stringify(item));
+    body = lines.length > 0 ? `${lines.join('\n')}\n` : '';
+    rowsWritten = lines.length;
+  }
+
+  const ws = createWriteStream(params.destination);
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    ws.on('error', rejectPromise);
+    ws.on('finish', resolvePromise);
+    ws.end(body);
+  });
+
+  return rowsWritten;
+}
+
+export default function registerExportTools(
+  server: McpServer,
+  imapService: ImapService,
+  connections: ConnectionManager,
+): void {
+  server.tool(
+    'export_search',
+    'Run any search_emails / search_all_accounts query and stream the result set to a CSV or ' +
+      'NDJSON file under ~/Downloads/ (or a caller-supplied destination). Bypasses the MCP response ' +
+      'byte budget — returns only a summary (path, rows_written, truncated). Default CSV columns: ' +
+      'id, account, date, from, subject, labels, attachments, has_attachments, seen, flagged.',
+    {
+      account: z.string().optional().describe('Single-account mode'),
+      accounts: z
+        .array(z.string())
+        .optional()
+        .describe('Cross-account fan-out; defaults to every configured account'),
+      mailbox: z.string().default('INBOX'),
+      query: z.string().optional().default(''),
+      to: z.string().optional(),
+      from: z.string().optional(),
+      subject: z.string().optional(),
+      cc: z.string().optional(),
+      bcc: z.string().optional(),
+      text: z.string().optional(),
+      body: z.string().optional(),
+      since: z.string().optional(),
+      before: z.string().optional(),
+      on: z.string().optional(),
+      sent_since: z.string().optional(),
+      sent_before: z.string().optional(),
+      seen: z.boolean().optional(),
+      flagged: z.boolean().optional(),
+      has_attachment: z.boolean().optional(),
+      larger_than: z.number().optional(),
+      smaller_than: z.number().optional(),
+      answered: z.boolean().optional(),
+      draft: z.boolean().optional(),
+      deleted: z.boolean().optional(),
+      keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      not_keyword: z.union([z.string(), z.array(z.string())]).optional(),
+      header: z.record(z.string(), z.string()).optional(),
+      attachment_filename: z.string().optional(),
+      attachment_mimetype: z.string().optional(),
+      gmail_raw: z.string().optional(),
+      format: z.enum(['csv', 'ndjson']).default('csv'),
+      max_rows: z.number().int().min(1).max(50000).default(5000),
+      columns: z
+        .array(
+          z.enum([
+            'id',
+            'account',
+            'date',
+            'from',
+            'to',
+            'subject',
+            'flags',
+            'labels',
+            'attachments',
+            'preview',
+            'size',
+          ]),
+        )
+        .optional()
+        .describe('CSV only; ignored for NDJSON (NDJSON always writes full EmailMeta JSON)'),
+      destination: z
+        .string()
+        .optional()
+        .describe('Absolute path. Default: ~/Downloads/email-export-<ISO-ts>.{csv|ndjson}'),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async (params) => {
+      try {
+        const tsSlug = new Date().toISOString().replace(/[:.]/g, '-');
+        const defaultPath = join(homedir(), 'Downloads', `email-export-${tsSlug}.${params.format}`);
+        const destination = params.destination ?? defaultPath;
+
+        // Path safety — reject anything outside $HOME or /tmp.
+        assertSafeDestination(destination);
+
+        // Resolve account mode
+        let accountNames: string[] | null = null;
+        let accountName: string | null = null;
+        if (params.account) {
+          accountName = params.account;
+        } else if (params.accounts && params.accounts.length > 0) {
+          accountNames = params.accounts;
+        } else {
+          accountNames = connections.getAccountNames();
+        }
+
+        const { items, truncated } = await imapService.searchForExport(
+          accountNames,
+          accountName,
+          params.query ?? '',
+          {
+            mailbox: params.mailbox,
+            to: params.to,
+            from: params.from,
+            subject: params.subject,
+            cc: params.cc,
+            bcc: params.bcc,
+            text: params.text,
+            body: params.body,
+            since: params.since,
+            before: params.before,
+            on: params.on,
+            sentSince: params.sent_since,
+            sentBefore: params.sent_before,
+            seen: params.seen,
+            flagged: params.flagged,
+            hasAttachment: params.has_attachment,
+            largerThan: params.larger_than,
+            smallerThan: params.smaller_than,
+            answered: params.answered,
+            draft: params.draft,
+            deleted: params.deleted,
+            keyword: params.keyword,
+            notKeyword: params.not_keyword,
+            header: params.header,
+            attachmentFilename: params.attachment_filename,
+            attachmentMimetype: params.attachment_mimetype,
+            gmailRaw: params.gmail_raw,
+            maxRows: params.max_rows,
+          },
+        );
+
+        // Column list — CSV only. For NDJSON we always dump the full EmailMeta.
+        const columns: (CsvColumn | DefaultColumn)[] =
+          params.format === 'csv' ? (params.columns ?? [...DEFAULT_CSV_COLUMNS]) : [];
+
+        const rowsWritten = await writeExport({
+          format: params.format,
+          items,
+          columns,
+          destination,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(
+                {
+                  path: destination,
+                  rows_written: rowsWritten,
+                  truncated,
+                  format: params.format,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to export search: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/src/tools/register.test.ts
+++ b/src/tools/register.test.ts
@@ -10,6 +10,7 @@ vi.mock('./calendar.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./contacts.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./drafts.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./emails.tool.js', () => ({ default: vi.fn() }));
+vi.mock('./export.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./folders.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./health.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./label.tool.js', () => ({ default: vi.fn() }));

--- a/src/tools/register.test.ts
+++ b/src/tools/register.test.ts
@@ -16,6 +16,7 @@ vi.mock('./label.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./locate.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./mailboxes.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./manage.tool.js', () => ({ default: vi.fn() }));
+vi.mock('./saved-searches.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./scheduler.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./send.tool.js', () => ({ default: vi.fn() }));
 vi.mock('./templates.tool.js', () => ({
@@ -59,6 +60,7 @@ function createConfig(readOnly: boolean): AppConfig {
       },
     },
     accounts: [],
+    searches: [],
   };
 }
 
@@ -74,6 +76,7 @@ describe('registerAllTools', () => {
       {} as never,
       {} as never,
       createConfig(false),
+      {} as never,
       {} as never,
       {} as never,
       {} as never,
@@ -103,6 +106,7 @@ describe('registerAllTools', () => {
       {} as never,
       {} as never,
       createConfig(true),
+      {} as never,
       {} as never,
       {} as never,
       {} as never,

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -26,6 +26,7 @@ import registerCalendarTools from './calendar.tool.js';
 import registerContactsTools from './contacts.tool.js';
 import registerDraftTools from './drafts.tool.js';
 import registerEmailsTools from './emails.tool.js';
+import registerExportTools from './export.tool.js';
 import registerFolderTools from './folders.tool.js';
 import registerHealthTools from './health.tool.js';
 import registerLabelTools from './label.tool.js';
@@ -60,7 +61,8 @@ export default function registerAllTools(
   registerAccountsTools(server, connections);
   registerMailboxesTools(server, imapService);
   registerEmailsTools(server, imapService, connections);
-  registerAttachmentTools(server, imapService);
+  registerAttachmentTools(server, imapService, connections);
+  registerExportTools(server, imapService, connections);
   registerContactsTools(server, imapService);
   registerThreadTools(server, imapService);
   registerTemplateReadTools(server, templateService);

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -13,6 +13,7 @@ import type ImapService from '../services/imap.service.js';
 import type LocalCalendarService from '../services/local-calendar.service.js';
 import type RemindersService from '../services/reminders.service.js';
 import type SchedulerService from '../services/scheduler.service.js';
+import type { SearchPresetRegistry } from '../services/search-presets.js';
 import type SmtpService from '../services/smtp.service.js';
 import type TemplateService from '../services/template.service.js';
 import type WatcherService from '../services/watcher.service.js';
@@ -31,6 +32,7 @@ import registerLabelTools from './label.tool.js';
 import registerLocateTools from './locate.tool.js';
 import registerMailboxesTools from './mailboxes.tool.js';
 import registerManageTools from './manage.tool.js';
+import registerSavedSearchesTools from './saved-searches.tool.js';
 import registerSchedulerTools from './scheduler.tool.js';
 import registerSendTools from './send.tool.js';
 import { registerTemplateReadTools, registerTemplateWriteTools } from './templates.tool.js';
@@ -50,13 +52,14 @@ export default function registerAllTools(
   schedulerService: SchedulerService,
   watcherService: WatcherService,
   hooksService: HooksService,
+  searchPresetRegistry: SearchPresetRegistry,
 ): void {
   const { readOnly } = config.settings;
 
   // Read tools — always registered
   registerAccountsTools(server, connections);
   registerMailboxesTools(server, imapService);
-  registerEmailsTools(server, imapService);
+  registerEmailsTools(server, imapService, connections);
   registerAttachmentTools(server, imapService);
   registerContactsTools(server, imapService);
   registerThreadTools(server, imapService);
@@ -71,7 +74,8 @@ export default function registerAllTools(
   registerAnalyticsTools(server, imapService);
   registerHealthTools(server, connections, imapService);
   registerLocateTools(server, imapService);
-  registerWatcherTools(server, watcherService, hooksService);
+  registerWatcherTools(server, watcherService, hooksService, searchPresetRegistry);
+  registerSavedSearchesTools(server, imapService, connections, searchPresetRegistry);
 
   // Write tools — skipped in read-only mode
   if (!readOnly) {

--- a/src/tools/saved-searches.tool.ts
+++ b/src/tools/saved-searches.tool.ts
@@ -1,0 +1,153 @@
+/**
+ * MCP tool: run_preset — executes a saved-search preset defined in
+ * config.toml under `[[searches]]`. Cross-account aware: uses
+ * `searchAcrossAccounts` when the preset defines `accounts[]`, otherwise
+ * falls back to single-account `searchEmails`.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import type ConnectionManager from '../connections/manager.js';
+import type ImapService from '../services/imap.service.js';
+import type { SearchOptions } from '../services/imap.service.js';
+import type { SearchPresetRegistry } from '../services/search-presets.js';
+import type { SearchPreset } from '../types/index.js';
+import { formatSearchResult } from './emails.tool.js';
+
+/** Translate a preset (camelCase) into the SearchOptions shape. */
+function presetToSearchOptions(
+  preset: SearchPreset,
+  page: number,
+  pageSize: number,
+): SearchOptions {
+  return {
+    mailbox: preset.mailbox,
+    page,
+    pageSize,
+    to: preset.to,
+    from: preset.from,
+    subject: preset.subject,
+    cc: preset.cc,
+    bcc: preset.bcc,
+    text: preset.text,
+    body: preset.body,
+    since: preset.since,
+    before: preset.before,
+    on: preset.on,
+    sentSince: preset.sentSince,
+    sentBefore: preset.sentBefore,
+    seen: preset.seen,
+    flagged: preset.flagged,
+    answered: preset.answered,
+    draft: preset.draft,
+    deleted: preset.deleted,
+    keyword: preset.keyword,
+    notKeyword: preset.notKeyword,
+    header: preset.header,
+    hasAttachment: preset.hasAttachment,
+    largerThan: preset.largerThan,
+    smallerThan: preset.smallerThan,
+    attachmentFilename: preset.attachmentFilename,
+    attachmentMimetype: preset.attachmentMimetype,
+    facets: preset.facets,
+    gmailRaw: preset.gmailRaw,
+  };
+}
+
+export default function registerSavedSearchesTools(
+  server: McpServer,
+  imapService: ImapService,
+  connections: ConnectionManager,
+  registry: SearchPresetRegistry,
+): void {
+  server.tool(
+    'run_preset',
+    'Run a saved search preset defined in config.toml under [[searches]]. ' +
+      'Presets bundle a named filter combination you can reuse. ' +
+      'Use list_presets to see available search presets. ' +
+      'Pass pagination to page through large result sets.',
+    {
+      name: z.string().describe('Preset name from config.toml [[searches]] or list_presets'),
+      page: z.number().int().min(1).default(1).optional(),
+      pageSize: z.number().int().min(1).max(100).default(20).optional(),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async ({ name, page, pageSize }) => {
+      const resolvedPage = page ?? 1;
+      const resolvedPageSize = pageSize ?? 20;
+
+      const preset = registry.get(name);
+      if (!preset) {
+        const available = registry.list().map((p) => p.name);
+        const availableHint =
+          available.length > 0
+            ? ` Available: ${available.join(', ')}`
+            : ' (no saved searches defined in config.toml)';
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Search preset "${name}" not found.${availableHint}`,
+            },
+          ],
+        };
+      }
+
+      try {
+        const options = presetToSearchOptions(preset, resolvedPage, resolvedPageSize);
+        const query = preset.query ?? '';
+
+        const presetAccounts = preset.accounts ?? [];
+        const isCrossAccount = presetAccounts.length > 0;
+        const result = isCrossAccount
+          ? await imapService.searchAcrossAccounts(presetAccounts, query, options)
+          : await (async () => {
+              const account = preset.account ?? connections.getAccountNames()[0];
+              if (!account) {
+                throw new Error(
+                  'No accounts configured — cannot run preset without an account target.',
+                );
+              }
+              return imapService.searchEmails(account, query, options);
+            })();
+
+        const totalDisplay = result.totalApprox ? `~${result.total}` : `${result.total}`;
+        const queryLabel = query ? `"${query}"` : 'filters';
+        const totalPages = result.total > 0 ? Math.ceil(result.total / result.pageSize) : 1;
+
+        const scopeLabel = isCrossAccount
+          ? `${presetAccounts.length} account(s) · ${preset.mailbox ?? 'INBOX'}`
+          : `${preset.account ?? connections.getAccountNames()[0]} · ${preset.mailbox ?? 'INBOX'}`;
+
+        const descLine = preset.description ? `\n   ${preset.description}` : '';
+        const header =
+          `📋 Preset "${preset.name}"${descLine}\n` +
+          `🔍 [${scopeLabel}] ${totalDisplay} result(s) for ${queryLabel} ` +
+          `(page ${result.page}/${totalPages})\n`;
+
+        const emptyMsg = `No emails found for preset "${preset.name}".`;
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: formatSearchResult(result, header, emptyMsg),
+            },
+          ],
+        };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to run preset "${name}": ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/src/tools/watcher.tool.ts
+++ b/src/tools/watcher.tool.ts
@@ -9,6 +9,7 @@ import { loadRawConfig, saveConfig } from '../config/loader.js';
 import type HooksService from '../services/hooks.service.js';
 import NotifierService from '../services/notifier.service.js';
 import { listPresets as listAllPresets } from '../services/presets.js';
+import type { SearchPresetRegistry } from '../services/search-presets.js';
 import type WatcherService from '../services/watcher.service.js';
 import type { AlertsConfig } from '../types/index.js';
 
@@ -16,6 +17,7 @@ export default function registerWatcherTools(
   server: McpServer,
   watcherService: WatcherService,
   hooksService: HooksService,
+  searchPresetRegistry: SearchPresetRegistry,
 ): void {
   const hooksConfig = hooksService.getHooksConfig();
   // -------------------------------------------------------------------------
@@ -63,29 +65,40 @@ export default function registerWatcherTools(
 
   server.tool(
     'list_presets',
-    'List all available AI triage presets with their descriptions and suggested labels.',
+    'List all available AI triage presets AND saved search presets (from [[searches]] in config.toml).',
     {},
     { readOnlyHint: true, destructiveHint: false },
     async () => {
       const presets = listAllPresets();
       const activePreset = hooksConfig.preset;
 
-      const lines = presets.map((p) => {
+      const hookLines = presets.map((p) => {
         const active = p.id === activePreset ? ' ✅ (active)' : '';
         const labels =
           p.suggestedLabels.length > 0 ? `\n     Labels: ${p.suggestedLabels.join(', ')}` : '';
         return `• ${p.name} [${p.id}]${active}\n     ${p.description}${labels}`;
       });
 
+      const savedSearches = searchPresetRegistry.list();
+      const savedLines =
+        savedSearches.length > 0
+          ? savedSearches.map((s) => {
+              const scope = s.accounts?.length
+                ? s.accounts.join(',')
+                : (s.account ?? '(default account)');
+              const desc = s.description ? ` — ${s.description}` : '';
+              return `  • ${s.name}${desc} (scope: ${scope})`;
+            })
+          : ['  (none — add [[searches]] to config.toml)'];
+
+      const text =
+        `🎯 Available Hook Presets:\n\n${hookLines.join('\n\n')}` +
+        `\n\nTo change preset, set \`preset = "${activePreset}"\` in [settings.hooks] of your config.toml.` +
+        `\n\n📋 Saved searches (from config.toml)\n${savedLines.join('\n')}` +
+        `\n\nRun a saved search with the \`run_preset\` tool (pass \`name\`).`;
+
       return {
-        content: [
-          {
-            type: 'text' as const,
-            text:
-              `🎯 Available Hook Presets:\n\n${lines.join('\n\n')}` +
-              `\n\nTo change preset, set \`preset = "${activePreset}"\` in [settings.hooks] of your config.toml.`,
-          },
-        ],
+        content: [{ type: 'text' as const, text }],
       };
     },
   );

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,13 @@ export interface PaginatedResult<T> {
   page: number;
   pageSize: number;
   hasMore: boolean;
+  /** Optional human-readable warning (e.g. "Truncated to 5000 of 78000 matches"). */
+  warning?: string;
+  /**
+   * When true, `total` is an approximation — typically because the server
+   * returned more UIDs than the cap and results were truncated before counting.
+   */
+  totalApprox?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -454,3 +454,28 @@ export interface ScheduledEmail {
   sentAt?: string;
   sentMessageId?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Export & Attachment Save — PR 4
+// ---------------------------------------------------------------------------
+
+export interface ExportResult {
+  path: string;
+  rows_written: number;
+  truncated: boolean;
+  format: 'csv' | 'ndjson';
+}
+
+export interface AttachmentSaveResult {
+  path: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface BatchAttachmentResult {
+  folder: string;
+  files_saved: number;
+  total_size: number;
+  skipped: number;
+  errors: { emailId: string; filename: string; error: string }[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,9 @@ export interface AccountConfig {
   oauth2?: OAuth2Config;
   imap: ImapConfig;
   smtp: SmtpConfig;
+  sentFolder?: string;
+  saveToSent?: boolean;
+  gmailAutoSave?: boolean;
 }
 
 export interface WatcherConfig {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -175,6 +175,12 @@ export interface EmailMeta {
   hasAttachments: boolean;
   labels: string[];
   preview?: string;
+  /**
+   * Attachment metadata, populated when bodyStructure is fetched. Undefined
+   * means "unknown" (e.g. envelope-only fetches); an empty array means the
+   * message was inspected and has no attachments.
+   */
+  attachments?: AttachmentMeta[];
 }
 
 export interface AttachmentMeta {
@@ -217,6 +223,17 @@ export interface PaginatedResult<T> {
    * returned more UIDs than the cap and results were truncated before counting.
    */
   totalApprox?: boolean;
+  /** Optional bucketed counts across the full match set (capped). */
+  facets?: FacetResult;
+}
+
+export interface FacetResult {
+  /** Map of sender address (lowercased) → count. */
+  sender?: Record<string, number>;
+  /** Map of year (stringified) → count. */
+  year?: Record<string, number>;
+  /** Map of mailbox path → count. Reserved for cross-account search. */
+  mailbox?: Record<string, number>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -145,6 +145,55 @@ export interface AppConfig {
     hooks: HooksConfig;
   };
   accounts: AccountConfig[];
+  /** Saved-search presets from `[[searches]]` in config.toml. Empty when none. */
+  searches: SearchPreset[];
+}
+
+// ---------------------------------------------------------------------------
+// Saved-search presets
+// ---------------------------------------------------------------------------
+
+/**
+ * Camel-cased view of a `[[searches]]` entry from config.toml. Bundles a
+ * named filter combination that can be executed via `run_preset`.
+ *
+ * Every search parameter mirrors the `SearchParams` shape. Either `account`
+ * (single-account) or `accounts` (cross-account) may be set — not both.
+ */
+export interface SearchPreset {
+  name: string;
+  description?: string;
+  account?: string;
+  accounts?: string[];
+  mailbox?: string;
+  query?: string;
+  to?: string;
+  from?: string;
+  subject?: string;
+  cc?: string;
+  bcc?: string;
+  text?: string;
+  body?: string;
+  since?: string;
+  before?: string;
+  on?: string;
+  sentSince?: string;
+  sentBefore?: string;
+  seen?: boolean;
+  flagged?: boolean;
+  answered?: boolean;
+  draft?: boolean;
+  deleted?: boolean;
+  keyword?: string | string[];
+  notKeyword?: string | string[];
+  header?: Record<string, string>;
+  largerThan?: number;
+  smallerThan?: number;
+  hasAttachment?: boolean;
+  attachmentFilename?: string;
+  attachmentMimetype?: string;
+  facets?: ('sender' | 'year' | 'mailbox')[];
+  gmailRaw?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -181,6 +230,12 @@ export interface EmailMeta {
    * message was inspected and has no attachments.
    */
   attachments?: AttachmentMeta[];
+  /**
+   * Account name — populated only by cross-account search
+   * (`ImapService.searchAcrossAccounts`). Single-account callers leave this
+   * undefined.
+   */
+  account?: string;
 }
 
 export interface AttachmentMeta {

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,83 @@
+import { normalizeDate } from './date.js';
+
+describe('normalizeDate', () => {
+  it('parses full ISO 8601 with time and Z', () => {
+    const d = normalizeDate('2024-01-15T10:00:00Z');
+    expect(d).toBeInstanceOf(Date);
+    expect(d.toISOString()).toBe('2024-01-15T10:00:00.000Z');
+  });
+
+  it('parses YYYY-MM-DD as UTC midnight', () => {
+    const d = normalizeDate('2024-01-15');
+    expect(d).toBeInstanceOf(Date);
+    expect(d.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('parses "today" as UTC midnight of current day', () => {
+    const d = normalizeDate('today');
+    const now = new Date();
+    expect(d.getUTCFullYear()).toBe(now.getUTCFullYear());
+    expect(d.getUTCMonth()).toBe(now.getUTCMonth());
+    expect(d.getUTCDate()).toBe(now.getUTCDate());
+    expect(d.getUTCHours()).toBe(0);
+    expect(d.getUTCMinutes()).toBe(0);
+    expect(d.getUTCSeconds()).toBe(0);
+  });
+
+  it('parses "yesterday" as UTC midnight of previous day', () => {
+    const d = normalizeDate('yesterday');
+    const expected = new Date();
+    expected.setUTCDate(expected.getUTCDate() - 1);
+    expect(d.getUTCFullYear()).toBe(expected.getUTCFullYear());
+    expect(d.getUTCMonth()).toBe(expected.getUTCMonth());
+    expect(d.getUTCDate()).toBe(expected.getUTCDate());
+    expect(d.getUTCHours()).toBe(0);
+  });
+
+  it('parses "7d" as 7 days ago (UTC midnight)', () => {
+    const d = normalizeDate('7d');
+    const now = new Date();
+    const expectedMs =
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) - 7 * 24 * 60 * 60 * 1000;
+    expect(d.getTime()).toBe(expectedMs);
+  });
+
+  it('parses "3w" as 21 days ago', () => {
+    const d = normalizeDate('3w');
+    const now = new Date();
+    const expectedMs =
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) -
+      21 * 24 * 60 * 60 * 1000;
+    expect(d.getTime()).toBe(expectedMs);
+  });
+
+  it('parses "2m" as 2 months ago', () => {
+    const d = normalizeDate('2m');
+    const now = new Date();
+    const expected = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    expected.setUTCMonth(expected.getUTCMonth() - 2);
+    expect(d.getTime()).toBe(expected.getTime());
+  });
+
+  it('parses relative tokens case-insensitively', () => {
+    const a = normalizeDate('7D');
+    const b = normalizeDate('7d');
+    expect(a.getTime()).toBe(b.getTime());
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeDate('  2024-01-15  ').toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('throws Error with "Invalid date: " prefix on garbage input', () => {
+    expect(() => normalizeDate('not a date')).toThrow(/^Invalid date: not a date$/);
+  });
+
+  it('throws on empty string', () => {
+    expect(() => normalizeDate('')).toThrow(/^Invalid date: $/);
+  });
+
+  it('throws on out-of-range month', () => {
+    expect(() => normalizeDate('2024-13-01')).toThrow(/^Invalid date: 2024-13-01$/);
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,81 @@
+/**
+ * Date parsing utilities for Power Search filters.
+ *
+ * `normalizeDate` accepts several user-friendly formats and returns a `Date`:
+ *   - ISO 8601            e.g. `2024-01-15T10:00:00Z`
+ *   - `YYYY-MM-DD`        e.g. `2024-01-15` (parsed as UTC midnight)
+ *   - Relative tokens     e.g. `7d`, `3w`, `2m` (days/weeks/months ago)
+ *   - Named tokens        `today`, `yesterday`
+ *
+ * Throws `Error` with message `Invalid date: ${input}` for unparseable input.
+ */
+
+const RELATIVE_PATTERN = /^(\d+)([dwm])$/i;
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function startOfDayUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+// eslint-disable-next-line import-x/prefer-default-export -- named export keeps call site self-documenting (`normalizeDate('7d')`)
+export function normalizeDate(input: string): Date {
+  if (typeof input !== 'string') {
+    throw new Error(`Invalid date: ${String(input)}`);
+  }
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  // Named tokens
+  if (lower === 'today') {
+    return startOfDayUtc(new Date());
+  }
+  if (lower === 'yesterday') {
+    const d = startOfDayUtc(new Date());
+    d.setUTCDate(d.getUTCDate() - 1);
+    return d;
+  }
+
+  // Relative tokens: Nd, Nw, Nm
+  const rel = RELATIVE_PATTERN.exec(lower);
+  if (rel) {
+    const amount = Number.parseInt(rel[1], 10);
+    const unit = rel[2];
+    const d = startOfDayUtc(new Date());
+    if (unit === 'd') d.setUTCDate(d.getUTCDate() - amount);
+    else if (unit === 'w') d.setUTCDate(d.getUTCDate() - amount * 7);
+    else if (unit === 'm') d.setUTCMonth(d.getUTCMonth() - amount);
+    return d;
+  }
+
+  // YYYY-MM-DD — parse as UTC midnight (avoid local TZ drift)
+  if (ISO_DATE_ONLY.test(trimmed)) {
+    const [y, m, day] = trimmed.split('-').map((s) => Number.parseInt(s, 10));
+    if (
+      !Number.isFinite(y) ||
+      !Number.isFinite(m) ||
+      !Number.isFinite(day) ||
+      m < 1 ||
+      m > 12 ||
+      day < 1 ||
+      day > 31
+    ) {
+      throw new Error(`Invalid date: ${input}`);
+    }
+    const dt = new Date(Date.UTC(y, m - 1, day));
+    if (Number.isNaN(dt.getTime())) {
+      throw new Error(`Invalid date: ${input}`);
+    }
+    return dt;
+  }
+
+  // Full ISO 8601
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  return parsed;
+}


### PR DESCRIPTION
## Summary

This PR adds automatic IMAP Sent folder append after every email send (new, reply, forward, draft), so sent messages appear in the mail client's Sent folder. Many IMAP servers — including cPanel/Dovecot hosted accounts — do not automatically save a copy to Sent when mail is sent via SMTP. This feature handles that reliably on the client side.

- **feat(smtp):** After a successful SMTP send, the raw RFC 822 message is appended to the account's Sent folder via IMAP APPEND
- **fix(smtp):** Sent folder is resolved correctly using a three-tier strategy: config override → RFC 6154 SPECIAL-USE (`\Sent`) → common name fallback
- **docs:** Added `config.example.toml` template and `docs/troubleshooting-sent-folder.md` covering a real-world edge case

## How It Works

`SmtpService` calls `ImapService.appendToSent()` after every send. The `resolveSentFolder()` method determines the correct folder:

1. **Config override** — `sent_folder` key in `config.toml` (highest priority, bypasses server query)
2. **RFC 6154 SPECIAL-USE** — finds the mailbox with `specialUse === '\Sent'` from `IMAP LIST`
3. **Common name fallback** — checks `INBOX.Sent`, `Sent`, `Sent Items`, `Sent Mail`, `[Gmail]/Sent Mail`, etc.

Gmail is skipped by default (`gmailAutoSave`) since Gmail auto-saves via SMTP. iCloud and standard IMAP servers use the detection logic.

## Real-World Edge Case: cPanel + Mac Mail

Discovered and documented during testing on cPanel/Dovecot hosted accounts paired with Mac Mail:

cPanel servers expose **two** sent folders:
- `INBOX.Sent` — has `specialUse: \Sent` (RFC 6154), picked up by auto-detection
- `INBOX.Sent Messages` — no SPECIAL-USE attribute, but this is the folder Mac Mail designated as its sent mailbox (paper airplane icon) when the account was first configured

Without the `sent_folder` override, appended messages land in `INBOX.Sent` while Mac Mail watches `INBOX.Sent Messages` — the user sees sent copies in the "wrong" folder.

**Fix:** Set `sent_folder = "INBOX.Sent Messages"` per account in `config.toml`. Fully documented in `docs/troubleshooting-sent-folder.md` with root cause analysis, a debug script for identifying folder names on any server, and an explanation of the resolution algorithm.

## Files Changed

| File | Change |
|------|--------|
| `src/services/smtp.service.ts` | `appendToSentFolder()` helper; called after send/reply/forward/draft |
| `src/services/imap.service.ts` | `resolveSentFolder()` + `appendToSent()` implementation |
| `src/services/smtp.service.test.ts` | Tests for Gmail skip, config override, append on send |
| `src/services/imap.service.test.ts` | Tests for SPECIAL-USE detection, fallback, folder creation |
| `config.example.toml` | Full config template with passwords blanked, `sent_folder` pre-applied for cPanel stanzas |
| `docs/troubleshooting-sent-folder.md` | Deep-dive on the cPanel/Mac Mail dual sent-folder issue |

## Test Plan

- [x] All 167 existing tests pass (`pnpm test`)
- [x] Biome + ESLint checks pass (`pnpm check`)
- [x] Tested live against 6 cPanel/Dovecot accounts — sent copies appear in Mac Mail's paper airplane Sent folder
- [x] Gmail account correctly skips IMAP append (server auto-saves)
- [x] `sent_folder` config override confirmed working (bypasses auto-detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)