### PR TITLE
feat(alerts): include uid, folder, hasAttachments in webhook payload

### DIFF
--- a/src/services/hooks.service.ts
+++ b/src/services/hooks.service.ts
@@ -302,6 +302,9 @@ export default class HooksService {
       priority: actions.flag ? 'high' : 'normal',
       labels: actions.labels,
       ruleName: rule.name,
+      uid: email.meta.id,
+      folder: email.mailbox,
+      hasAttachments: email.meta.hasAttachments,
     };
     await this.notifier.alert(payload, actions.alert === true);
 
@@ -352,6 +355,9 @@ export default class HooksService {
         sender: e.meta.from,
         subject: e.meta.subject,
         priority: 'normal',
+        uid: e.meta.id,
+        folder: e.mailbox,
+        hasAttachments: e.meta.hasAttachments,
       };
       return this.notifier.alert(payload);
     });
@@ -463,6 +469,9 @@ export default class HooksService {
       subject: email.meta.subject,
       priority,
       labels: triage.labels,
+      uid: email.meta.id,
+      folder: email.mailbox,
+      hasAttachments: email.meta.hasAttachments,
     };
     await this.notifier.alert(payload);
     if (triage.action) {

--- a/src/services/notifier.service.ts
+++ b/src/services/notifier.service.ts
@@ -29,6 +29,9 @@ export interface AlertPayload {
   priority: UrgencyLevel;
   labels?: string[];
   ruleName?: string;
+  uid?: string;
+  folder?: string;
+  hasAttachments?: boolean;
 }
 
 export interface PlatformDiagnostics {
@@ -382,8 +385,11 @@ export default class NotifierService {
     const body = JSON.stringify({
       event: `email.${payload.priority}`,
       account: payload.account,
+      uid: payload.uid ?? null,
+      folder: payload.folder ?? null,
       sender: payload.sender,
       subject: payload.subject,
+      hasAttachments: payload.hasAttachments ?? false,
       priority: payload.priority,
       labels: payload.labels ?? [],
       rule: payload.ruleName ?? null,


### PR DESCRIPTION
## Summary

- Add `uid` (IMAP UID), `folder` (mailbox name), and `hasAttachments` to `AlertPayload` and webhook JSON body
- Thread these fields through all 3 payload construction sites in `hooks.service.ts`

Closes #17

## Motivation

Webhook consumers that receive email alerts currently cannot fetch the full email content because the payload lacks the IMAP UID. The `uid` is already available on `EmailMeta.id` at all call sites -- it was just not being passed through to the webhook.

With this change, a consumer can call `get_email` with the received `uid` to retrieve the full body, attachments, and headers.

## Changes

- **`notifier.service.ts`**: Added `uid?`, `folder?`, `hasAttachments?` to `AlertPayload` interface. Added these fields to the webhook JSON body in `sendWebhook()`.
- **`hooks.service.ts`**: Pass `email.meta.id`, `email.mailbox`, `email.meta.hasAttachments` at all 3 sites where `AlertPayload` is constructed (`applyStaticRule`, `notifyBatch`, `applySingleTriage`).

## Backward compatibility

All new fields are optional in `AlertPayload` and default to `null`/`false` in the webhook JSON. Existing consumers are unaffected.

## New webhook payload shape

```json
{
  "event": "email.normal",
  "account": "personal",
  "uid": "12345",
  "folder": "INBOX",
  "sender": { "name": "John", "address": "john@example.com" },
  "subject": "Hello",
  "hasAttachments": true,
  "priority": "normal",
  "labels": [],
  "rule": null,
  "timestamp": "2026-03-20T..."
}
```

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `vitest run` -- all 150 tests pass
- [x] `biome check` passes on changed files