### PR TITLE
fix: coerce page/pageSize params to number in list_emails and search_emails

### DIFF
--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -123,8 +123,8 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
     {
       account: z.string().describe('Account name from list_accounts'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
-      page: z.number().int().min(1).default(1).describe('Page number'),
-      pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
+      page: z.coerce.number().int().min(1).default(1).describe('Page number'),
+      pageSize: z.coerce.number().int().min(1).max(100).default(20).describe('Results per page'),
       since: z.string().optional().describe('Show emails after this date (ISO 8601)'),
       before: z.string().optional().describe('Show emails before this date (ISO 8601)'),
       from: z.string().optional().describe('Filter by sender address or name'),
@@ -431,8 +431,8 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .default('')
         .describe('Search keyword (omit or leave empty to use filters only)'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
-      page: z.number().int().min(1).default(1).describe('Page number'),
-      pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
+      page: z.coerce.number().int().min(1).default(1).describe('Page number'),
+      pageSize: z.coerce.number().int().min(1).max(100).default(20).describe('Results per page'),
       to: z.string().optional().describe('Filter by recipient address'),
       has_attachment: z
         .boolean()


### PR DESCRIPTION
MCP callers send all parameters as strings. `z.number()` rejects string "20" with a type error; `z.coerce.number()` accepts it. Without this fix, pagination breaks for any caller that doesn't pre-cast the value.

Tested against Gmail and other IMAP providers.