### PR TITLE
fix(imap): attach error/close handlers to prevent silent exit on idle drops

### DIFF
--- a/src/connections/manager.ts
+++ b/src/connections/manager.ts
@@ -96,6 +96,38 @@ export default class ConnectionManager implements IConnectionManager {
       logger: false,
     });
 
+    // Attach error/close handlers BEFORE connect so we never miss an event.
+    //
+    // Without these, an idle IMAP connection that the server later drops (most
+    // hosted providers close IDLE sessions after ~29 min) emits an `error`
+    // event with no listener — Node treats that as an uncaughtException and
+    // exits the process silently. Because `logger: false` swallows stderr,
+    // there is no trace in the MCP log; the server simply disappears mid
+    // session and the client (Claude Code, Cursor, etc.) reports the tools as
+    // disconnected with no obvious cause.
+    //
+    // Swallow the error, log it, and drop the stale entry so the next call to
+    // `getImapClient` lazy-reconnects via the existing `usable` check.
+    client.on('error', (err: unknown) => {
+      mcpLog(
+        'warning',
+        'imap',
+        `Connection error for "${accountName}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      ).catch(() => {
+        /* swallow — logging must not throw in an error handler */
+      });
+      if (this.imapClients.get(accountName) === client) {
+        this.imapClients.delete(accountName);
+      }
+    });
+    client.on('close', () => {
+      if (this.imapClients.get(accountName) === client) {
+        this.imapClients.delete(accountName);
+      }
+    });
+
     await client.connect();
     await mcpLog(
       'info',


### PR DESCRIPTION
## Problem

`ConnectionManager.getImapClient` creates an `ImapFlow` client without attaching `error` or `close` listeners. When the IMAP server drops an idle connection — which most hosted providers do after ~29 minutes (Hostinger in our case) — ImapFlow emits `error`. With no listener, Node treats it as `uncaughtException` and exits the process.

Because the client is constructed with `logger: false`, **nothing is written to stderr**. From the user's perspective the MCP server simply disappears mid-session and Claude Code / Cursor reports the tools as deferred/disconnected with no trace in the MCP log.

We hit this reproducibly on Hostinger: every session went silent ~30 minutes after the last successful tool call. Log file showed clean tool calls then nothing — no error, no shutdown line.

## Fix

Attach `error` and `close` handlers **before** `client.connect()` so we never miss an event:

- `error`: log via `mcpLog` (catching its promise so the handler itself cannot throw) and drop the cached client.
- `close`: drop the cached client.

The next `getImapClient()` call then reconnects via the existing `usable` check — exactly the auto-reconnect behaviour the file's docstring already promises.

## Impact

- Healthy connections: no behavior change.
- Idle drops / network blips: self-heal instead of crashing the process.

## Verification

- `npm run build` — clean
- `npm run lint` — clean
- `npm test` — 150/150 pass
- Patched the same change into a local install; ran a session past the 29-min idle window — connection lazy-reconnected on the next tool call instead of taking the server down.

Open to feedback on log level (`warning` vs `info`) or whether the close handler should also log.