### PR TITLE
feat(search): add from/date filters and require explicit search criteria

### DIFF
--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -165,4 +165,62 @@ describe('ImapService', () => {
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
     });
   });
+
+  // -----------------------------------------------------------------------
+  // searchEmails — criteria builder
+  // -----------------------------------------------------------------------
+
+  describe('searchEmails', () => {
+    it('throws when no query and no filters are provided', async () => {
+      await expect(service.searchEmails('test', '')).rejects.toThrow(
+        /at least one of: query, from, to/,
+      );
+      expect(client.search).not.toHaveBeenCalled();
+    });
+
+    it('builds an OR criteria across subject/from/body for a keyword query', async () => {
+      await service.searchEmails('test', 'invoice');
+
+      expect(client.search).toHaveBeenCalledTimes(1);
+      const [criteria] = client.search.mock.calls[0];
+      expect(criteria).toMatchObject({
+        or: [{ subject: 'invoice' }, { from: 'invoice' }, { body: 'invoice' }],
+      });
+    });
+
+    it('AND-combines from with the OR keyword criteria', async () => {
+      await service.searchEmails('test', 'invoice', { from: 'billing@example.com' });
+
+      const [criteria] = client.search.mock.calls[0];
+      expect(criteria).toMatchObject({
+        or: [{ subject: 'invoice' }, { from: 'invoice' }, { body: 'invoice' }],
+        from: 'billing@example.com',
+      });
+    });
+
+    it('passes since/before/sentSince/sentBefore as Date objects', async () => {
+      await service.searchEmails('test', '', {
+        from: 'billing@example.com',
+        since: '2026-05-01T00:00:00Z',
+        before: '2026-05-08T00:00:00Z',
+        sentSince: '2026-05-01T00:00:00Z',
+        sentBefore: '2026-05-08T00:00:00Z',
+      });
+
+      const [criteria] = client.search.mock.calls[0];
+      expect(criteria.since).toBeInstanceOf(Date);
+      expect(criteria.before).toBeInstanceOf(Date);
+      expect(criteria.sentSince).toBeInstanceOf(Date);
+      expect(criteria.sentBefore).toBeInstanceOf(Date);
+      expect((criteria.since as Date).toISOString()).toBe('2026-05-01T00:00:00.000Z');
+      expect((criteria.before as Date).toISOString()).toBe('2026-05-08T00:00:00.000Z');
+    });
+
+    it('allows search with only a filter (no keyword)', async () => {
+      await expect(
+        service.searchEmails('test', '', { since: '2026-05-01T00:00:00Z' }),
+      ).resolves.toMatchObject({ items: [], total: 0 });
+      expect(client.search).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -500,7 +500,12 @@ export default class ImapService {
       mailbox?: string;
       page?: number;
       pageSize?: number;
+      from?: string;
       to?: string;
+      since?: string;
+      before?: string;
+      sentSince?: string;
+      sentBefore?: string;
       hasAttachment?: boolean;
       largerThan?: number;
       smallerThan?: number;
@@ -513,6 +518,27 @@ export default class ImapService {
     const pageSize = options.pageSize ?? 20;
     const sanitizedQuery = query ? sanitizeSearchQuery(query) : '';
 
+    // Reject "no query and no filters" — IMAP would return the entire mailbox,
+    // which silently turns search_emails into list_emails. Force callers to be
+    // explicit; if they really want everything they should call list_emails.
+    const hasAnyFilter =
+      !!sanitizedQuery ||
+      !!options.from ||
+      !!options.to ||
+      !!options.since ||
+      !!options.before ||
+      !!options.sentSince ||
+      !!options.sentBefore ||
+      options.hasAttachment !== undefined ||
+      options.largerThan !== undefined ||
+      options.smallerThan !== undefined ||
+      options.answered !== undefined;
+    if (!hasAnyFilter) {
+      throw new Error(
+        'search_emails requires at least one of: query, from, to, has_attachment, larger_than, smaller_than, answered. Use list_emails to browse a mailbox without filters.',
+      );
+    }
+
     const lock = await client.getMailboxLock(mailbox);
     try {
       // Build search criteria — base query OR across subject/from/body
@@ -523,8 +549,23 @@ export default class ImapService {
       // Build additional filters as AND conditions
       const andConditions: Record<string, unknown>[] = [baseCriteria];
 
+      if (options.from) {
+        andConditions.push({ from: options.from });
+      }
       if (options.to) {
         andConditions.push({ to: options.to });
+      }
+      if (options.since) {
+        andConditions.push({ since: new Date(options.since) });
+      }
+      if (options.before) {
+        andConditions.push({ before: new Date(options.before) });
+      }
+      if (options.sentSince) {
+        andConditions.push({ sentSince: new Date(options.sentSince) });
+      }
+      if (options.sentBefore) {
+        andConditions.push({ sentBefore: new Date(options.sentBefore) });
       }
       if (options.largerThan !== undefined) {
         andConditions.push({ larger: options.largerThan * 1024 });

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -421,19 +421,37 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
     'search_emails',
     'Search emails by keyword across subject, sender, and body. ' +
       'Omit query (or pass an empty string) to use it as a pure filter — e.g. find all emails ' +
-      'with attachments from a specific recipient without a keyword. ' +
-      'Supports additional filters for recipient, attachments, size, and reply status.',
+      'from a specific sender without a keyword. ' +
+      'Supports additional filters for sender, recipient, date range (since/before — INTERNALDATE; ' +
+      'sent_since/sent_before — Date: header), attachments, size, and reply status. ' +
+      'At least one of query/from/to/since/before/sent_since/sent_before/has_attachment/' +
+      'larger_than/smaller_than/answered must be set; otherwise the call errors ' +
+      '(use list_emails to browse without filters).',
     {
       account: z.string().describe('Account name from list_accounts'),
       query: z
         .string()
         .optional()
         .default('')
-        .describe('Search keyword (omit or leave empty to use filters only)'),
+        .describe('Search keyword across subject, sender, and body (omit to use filters only)'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
       page: z.number().int().min(1).default(1).describe('Page number'),
       pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
+      from: z.string().optional().describe('Filter by sender address (substring match)'),
       to: z.string().optional().describe('Filter by recipient address'),
+      since: z
+        .string()
+        .optional()
+        .describe('Only emails received on/after this date (ISO 8601, e.g. 2026-05-11T00:00:00Z)'),
+      before: z.string().optional().describe('Only emails received before this date (ISO 8601)'),
+      sent_since: z
+        .string()
+        .optional()
+        .describe('Only emails with Date: header on/after this date (ISO 8601)'),
+      sent_before: z
+        .string()
+        .optional()
+        .describe('Only emails with Date: header before this date (ISO 8601)'),
       has_attachment: z
         .boolean()
         .optional()
@@ -449,7 +467,12 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
           mailbox: params.mailbox,
           page: params.page,
           pageSize: params.pageSize,
+          from: params.from,
           to: params.to,
+          since: params.since,
+          before: params.before,
+          sentSince: params.sent_since,
+          sentBefore: params.sent_before,
           hasAttachment: params.has_attachment,
           largerThan: params.larger_than,
           smallerThan: params.smaller_than,


### PR DESCRIPTION
## Description

Two improvements to `search_emails`:

1. **New filters** — `from`, `since`, `before`, `sent_since`, `sent_before`.
   The underlying ImapFlow `SearchObject` already supported all of these;
   only the plumbing was missing. Mirrors the existing `to` field and the
   equivalent filters already exposed on `list_emails`.

2. **Reject all-empty calls** — previously, `search_emails` with no query
   and no filters ran `client.search({}, { uid: true })`, which matches
   every UID in the mailbox. This made the tool indistinguishable from
   `list_emails` for empty input and silently masked bugs where unknown
   parameter names were stripped by the Zod schema (e.g. a caller passing
   `keyword:` instead of `query:` would see a full-mailbox response with
   no hint that their argument had been dropped). Now throws a clear error
   pointing callers to `list_emails`.

### Motivating example

A common ask is "emails from sender X in the last N days." That used to
require `list_emails` (which already had `from` + `since`), even though
`search_emails` was the more semantically obvious tool for filtered
lookups. After this PR a single call works:

```json
{
  "account": "work",
  "from": "billing@example.com",
  "since": "2026-05-01T00:00:00Z"
}
```

Or combined with a keyword:

```json
{
  "account": "work",
  "query": "invoice",
  "since": "2026-04-01T00:00:00Z",
  "has_attachment": true
}
```

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change — `search_emails` with no filters now errors
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor

## Checklist

- [x] Code follows project style (Biome + ESLint — `pnpm check` passes)
- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes
- [x] All unit tests pass (`pnpm test`) — 155/155, including 5 new
      `searchEmails` criteria-builder tests
- [x] Tool description in `emails.tool.ts` updated to reflect new params

## Notes for reviewer

- The breaking-change behavior could alternatively be a deprecation
  warning that returns the full mailbox for one release. Happy to soften
  if you prefer a gentler landing.
- Pagination math is unchanged.
- Resolves: https://github.com/codefuturist/email-mcp/issues/31
