### PR TITLE
fix(claude): use Haiku 4.5 (Sonnet 4.6 quota exhausted on OAuth token)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,7 +60,10 @@ jobs:
           prompt: ${{ github.event.inputs.prompt || '' }}
           # Sign commits via the GitHub API so Claude's pushes are "Verified".
           use_commit_signing: true
-          # Cap turns + pin model. Bump model when a newer GA Sonnet ships.
+          # Cap turns + pin model. Haiku 4.5 is the working choice on the
+          # Max OAuth token here; Sonnet 4.6 hit a persistent 429 quota
+          # ceiling that the SDK surfaces as "401 Invalid bearer token".
+          # Swap to claude-sonnet-4-6 when quota or API-key billing allows.
           claude_args: |
             --max-turns 10
-            --model claude-sonnet-4-6
+            --model claude-haiku-4-5-20251001


### PR DESCRIPTION
End-to-end test hit persistent `401 Invalid bearer token` from the action. Direct API probe with the same OAuth token returns 200 on Haiku 4.5 but 429 rate-limit on Sonnet 4.6 — the SDK appears to surface that 429 as 401.

Switching the workflow's `--model` to `claude-haiku-4-5-20251001` unblocks the integration. Flip back to Sonnet 4.6 when quota resets or when an `sk-ant-api03-…` API key is wired up.