### PR TITLE
feat(smtp): quote original message in replies by default

### DIFF
--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -37,8 +37,29 @@ function createMockRateLimiter(allowed = true) {
   } as unknown as RateLimiter;
 }
 
-function createMockImapService() {
-  return {} as unknown as ImapService;
+function createMockImapService(overrides: Partial<ImapService> = {}) {
+  return overrides as unknown as ImapService;
+}
+
+function makeOriginalEmail() {
+  return {
+    id: '42',
+    subject: 'Project update',
+    from: { name: 'Alex', address: 'alex@example.com' },
+    to: [{ address: 'test@example.com' }],
+    cc: [],
+    date: 'Mon, 25 May 2026 16:11:00 +0200',
+    seen: true,
+    flagged: false,
+    answered: false,
+    hasAttachments: false,
+    labels: [],
+    messageId: '<orig-42@example.com>',
+    references: ['<root@example.com>'],
+    bodyText: 'Where are we on the launch?',
+    attachments: [],
+    headers: {},
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -123,6 +144,71 @@ describe('SmtpService', () => {
       const call = transport.sendMail.mock.calls[0][0];
       expect(call.html).toBe('<h1>Hello</h1>');
       expect(call.text).toBeUndefined();
+    });
+  });
+
+  describe('replyToEmail quote_original', () => {
+    it('appends quoted original below text reply by default', async () => {
+      const imap = createMockImapService({
+        getEmail: vi.fn().mockResolvedValue(makeOriginalEmail()),
+      } as unknown as Partial<ImapService>);
+      service = new SmtpService(connections, rateLimiter, imap);
+
+      await service.replyToEmail('test', {
+        emailId: '42',
+        body: 'On it tomorrow.',
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.text).toContain('On it tomorrow.');
+      expect(call.text).toContain(
+        'On Mon, 25 May 2026 16:11:00 +0200, Alex <alex@example.com> wrote:',
+      );
+      expect(call.text).toContain('> Where are we on the launch?');
+      expect(call.subject).toBe('Re: Project update');
+      expect(call.inReplyTo).toBe('<orig-42@example.com>');
+      expect(call.references).toContain('<root@example.com>');
+      expect(call.references).toContain('<orig-42@example.com>');
+    });
+
+    it('appends <blockquote type="cite"> for HTML replies', async () => {
+      const imap = createMockImapService({
+        getEmail: vi.fn().mockResolvedValue({
+          ...makeOriginalEmail(),
+          bodyHtml: '<p>Where are we?</p>',
+        }),
+      } as unknown as Partial<ImapService>);
+      service = new SmtpService(connections, rateLimiter, imap);
+
+      await service.replyToEmail('test', {
+        emailId: '42',
+        body: '<p>On it tomorrow.</p>',
+        html: true,
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.html).toContain('<p>On it tomorrow.</p>');
+      expect(call.html).toContain('<blockquote type="cite"');
+      expect(call.html).toContain('<p>Where are we?</p>');
+      expect(call.text).toBeUndefined();
+    });
+
+    it('does not append quoted block when quoteOriginal=false', async () => {
+      const imap = createMockImapService({
+        getEmail: vi.fn().mockResolvedValue(makeOriginalEmail()),
+      } as unknown as Partial<ImapService>);
+      service = new SmtpService(connections, rateLimiter, imap);
+
+      await service.replyToEmail('test', {
+        emailId: '42',
+        body: 'On it tomorrow.',
+        quoteOriginal: false,
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.text).toBe('On it tomorrow.');
+      expect(call.text).not.toContain('wrote:');
+      expect(call.text).not.toContain('>');
     });
   });
 });

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -7,6 +7,7 @@
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
 import type { SendResult } from '../types/index.js';
+import { quoteOriginalAsHtml, quoteOriginalAsText } from '../utils/quote.js';
 import type ImapService from './imap.service.js';
 
 export default class SmtpService {
@@ -63,6 +64,13 @@ export default class SmtpService {
       body: string;
       replyAll?: boolean;
       html?: boolean;
+      /**
+       * When true (default), the original message is appended below the reply
+       * as a quoted block (Thunderbird/Outlook style: "On DATE, NAME wrote:"
+       * followed by `>`-prefixed lines, or `<blockquote type="cite">` for HTML
+       * replies). Set false to send the bare reply body only.
+       */
+      quoteOriginal?: boolean;
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
@@ -96,6 +104,13 @@ export default class SmtpService {
       ? original.subject
       : `Re: ${original.subject}`;
 
+    // Append quoted original below the reply body unless explicitly disabled.
+    const includeQuote = options.quoteOriginal !== false;
+    let { body } = options;
+    if (includeQuote) {
+      body += options.html ? quoteOriginalAsHtml(original) : quoteOriginalAsText(original);
+    }
+
     const transport = await this.connections.getSmtpTransport(accountName);
 
     const result = await transport.sendMail({
@@ -105,7 +120,7 @@ export default class SmtpService {
       subject,
       inReplyTo: original.messageId,
       references: references.join(' '),
-      ...(options.html ? { html: options.body } : { text: options.body }),
+      ...(options.html ? { html: body } : { text: body }),
     });
 
     return {

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -80,6 +80,15 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       body: z.string().describe('Reply body content'),
       replyAll: z.boolean().default(false).describe('Reply to all recipients'),
       html: z.boolean().default(false).describe('Send as HTML'),
+      quoteOriginal: z
+        .boolean()
+        .default(true)
+        .describe(
+          'Append the original message as a quoted block below the reply ' +
+            '(Thunderbird/Outlook style: "On DATE, NAME wrote:" + > prefix for ' +
+            'text replies, or <blockquote type="cite"> for HTML). Disable to ' +
+            'send the bare reply body only.',
+        ),
     },
     { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     async (params) => {

--- a/src/utils/quote.test.ts
+++ b/src/utils/quote.test.ts
@@ -1,0 +1,69 @@
+import type { Email } from '../types/index.js';
+import { quoteOriginalAsHtml, quoteOriginalAsText } from './quote.js';
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: '1',
+    subject: 'Greetings',
+    from: { name: 'Alex Chery', address: 'alex@example.com' },
+    to: [{ address: 'me@example.com' }],
+    date: 'Mon, 25 May 2026 16:11:00 +0200',
+    seen: true,
+    flagged: false,
+    answered: false,
+    hasAttachments: false,
+    labels: [],
+    messageId: '<abc@example.com>',
+    bodyText: 'Hello there.\nHow are you?',
+    attachments: [],
+    headers: {},
+    ...overrides,
+  };
+}
+
+describe('quoteOriginalAsText', () => {
+  it('builds attribution and > prefix for each line', () => {
+    const out = quoteOriginalAsText(makeEmail());
+    expect(out).toBe(
+      '\n\nOn Mon, 25 May 2026 16:11:00 +0200, Alex Chery <alex@example.com> wrote:\n> Hello there.\n> How are you?',
+    );
+  });
+
+  it('falls back to stripped HTML when no bodyText', () => {
+    const out = quoteOriginalAsText(
+      makeEmail({ bodyText: undefined, bodyHtml: '<p>Hello</p><p>World</p>' }),
+    );
+    expect(out).toContain('> Hello');
+    expect(out).toContain('> World');
+  });
+
+  it('uses bare address when no display name', () => {
+    const out = quoteOriginalAsText(makeEmail({ from: { address: 'noreply@bot.com' } }));
+    expect(out).toContain('noreply@bot.com wrote:');
+  });
+
+  it('preserves blank lines with bare > prefix', () => {
+    const out = quoteOriginalAsText(makeEmail({ bodyText: 'A\n\nB' }));
+    expect(out).toContain('> A\n>\n> B');
+  });
+});
+
+describe('quoteOriginalAsHtml', () => {
+  it('wraps original HTML body in <blockquote type="cite">', () => {
+    const out = quoteOriginalAsHtml(makeEmail({ bodyHtml: '<p>Hi</p>' }));
+    expect(out).toContain('<blockquote type="cite"');
+    expect(out).toContain('<p>Hi</p>');
+    expect(out).toContain('Alex Chery &lt;alex@example.com&gt; wrote:');
+  });
+
+  it('wraps plain-text body in escaped <pre> when no HTML available', () => {
+    const out = quoteOriginalAsHtml(makeEmail({ bodyText: 'A < B', bodyHtml: undefined }));
+    expect(out).toContain('A &lt; B');
+    expect(out).toContain('<pre');
+  });
+
+  it('escapes attribution sender name', () => {
+    const out = quoteOriginalAsHtml(makeEmail({ from: { name: '<weird>', address: 'a@b.com' } }));
+    expect(out).toContain('&lt;weird&gt; &lt;a@b.com&gt; wrote:');
+  });
+});

--- a/src/utils/quote.ts
+++ b/src/utils/quote.ts
@@ -1,0 +1,83 @@
+/**
+ * Reply-quoting helpers — produce the "On <date>, <sender> wrote:" block
+ * + quoted original body that desktop clients (Thunderbird, Apple Mail,
+ * Outlook) automatically prepend to outgoing replies.
+ *
+ * Without this, replies sent through the MCP show up to the recipient as
+ * bare text with no context — they have to dig into the prior thread to
+ * understand what's being answered.
+ */
+
+import type { Email, EmailAddress } from '../types/index.js';
+
+/** Minimal HTML stripper for converting an HTML original into plain text. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<li\b[^>]*>/gi, '\n• ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/** Escape user-controlled text for safe HTML embedding. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatSender(addr: EmailAddress): string {
+  return addr.name ? `${addr.name} <${addr.address}>` : addr.address;
+}
+
+/**
+ * Produce a plain-text quoted block for a reply (Thunderbird/Mutt style):
+ *
+ *     On <date>, <sender> wrote:
+ *     > line 1
+ *     > line 2
+ */
+export function quoteOriginalAsText(original: Email): string {
+  const attribution = `On ${original.date}, ${formatSender(original.from)} wrote:`;
+  const body = original.bodyText ?? (original.bodyHtml ? stripHtml(original.bodyHtml) : '');
+  const quoted = body
+    .split('\n')
+    .map((line) => (line.length > 0 ? `> ${line}` : '>'))
+    .join('\n');
+  return `\n\n${attribution}\n${quoted}`;
+}
+
+/**
+ * Produce an HTML quoted block for an HTML reply, wrapped in the standard
+ * `<blockquote type="cite">` that mail clients recognize as quoted material.
+ */
+export function quoteOriginalAsHtml(original: Email): string {
+  const attribution = `On ${escapeHtml(original.date)}, ${escapeHtml(formatSender(original.from))} wrote:`;
+  let inner: string;
+  if (original.bodyHtml) {
+    inner = original.bodyHtml;
+  } else if (original.bodyText) {
+    inner = `<pre style="white-space:pre-wrap;font-family:inherit;margin:0">${escapeHtml(original.bodyText)}</pre>`;
+  } else {
+    inner = '';
+  }
+  return (
+    `<br><br>${attribution}<br>` +
+    `<blockquote type="cite" style="margin:0 0 0 .8ex;border-left:1px solid #ccc;padding-left:1ex">${
+      inner
+    }</blockquote>`
+  );
+}


### PR DESCRIPTION
## What

Adds a new `quoteOriginal: boolean` parameter (default `true`) to the `reply_email` MCP tool. When enabled (the default), the original message is appended below the user's reply body as a quoted block — the same convention every desktop client (Thunderbird, Outlook, Apple Mail) uses automatically.

## Why

Until now `reply_email` sent only the user-supplied body, so the recipient saw a context-free reply ("Sorry for the delay, can we do this now?") with no reference to what was being replied to. This makes the MCP feel less polished than a regular mail client and forces the recipient to dig into the thread to remember what's being answered.

There is no existing issue for this — opening it as a feature PR.

## Changes

- New `src/utils/quote.ts` produces:
  - **Plain text replies**: `On DATE, NAME <addr> wrote:` attribution line followed by `>`-prefixed original body (Thunderbird/Mutt style).
  - **HTML replies**: same attribution, original body wrapped in `<blockquote type="cite">` — recognized by every client as quoted material.
- For text replies whose original was HTML-only, the HTML is stripped to plain text first via the same stripper used elsewhere in the codebase (`emails.tool.ts`).
- For HTML replies whose original was text-only, the text is HTML-escaped and wrapped in `<pre>`.
- Sender names and email addresses in the HTML attribution are properly escaped to prevent injection.

## API

```ts
// reply_email tool now accepts:
{
  account: string;
  emailId: string;
  body: string;
  // ... existing params
  quoteOriginal?: boolean; // default true
}
```

Set `quoteOriginal: false` to send the bare body only (current behavior).

## Tests

- New `quote.test.ts` covers text/html quoting paths, name/address formatting, blank-line preservation, HTML escaping.
- Extended `smtp.service.test.ts` with a `replyToEmail quote_original` suite (default-on, html path, explicit opt-out).
- 160 tests pass (was 150).

## Manual integration test

End-to-end: account A sends a seed mail to account B → account B calls `reply_email` with default `quoteOriginal=true` → account A receives a reply containing both the new body on top AND the original quoted below. Verified the rendered output in Thunderbird matches expectations.