### PR TITLE
fix(server): exit stdio server when the client closes stdin

### DIFF
--- a/src/main.lifecycle.test.ts
+++ b/src/main.lifecycle.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Process lifecycle of the stdio transport.
+ *
+ * The MCP stdio contract is that the client shuts the server down by closing our
+ * stdin. Until this test existed the server never noticed: StdioServerTransport
+ * subscribes only to 'data' and 'error', and several services hold ref'd handles
+ * (scheduler tick, hooks rate-limit timer, IMAP IDLE sockets), so the event loop
+ * never drained. Any client death that skips SIGTERM — closed terminal, SIGKILL,
+ * crash, MCP reconnect — left an immortal process reparented to launchd/init.
+ *
+ * The server runs as a real child process on purpose: the defect is the event
+ * loop failing to drain, which is unobservable from inside the same process.
+ */
+
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const ENTRY = fileURLToPath(new URL('./main.ts', import.meta.url));
+
+/**
+ * Budget for the whole spawn → handshake → EOF → exit round trip. Everything in
+ * it is local, so this is generous; its job is to fail a regression fast instead
+ * of hanging CI until the framework timeout.
+ */
+const LIFECYCLE_BUDGET_MS = 20_000;
+
+/** Emitted by the server once post-handshake init has started the hooks service. */
+const READY_LOG = 'Email MCP server started';
+
+let child: ChildProcessWithoutNullStreams | undefined;
+let sandbox: string | undefined;
+
+/** A test about leaked processes must not leak one itself. */
+afterEach(async () => {
+  if (child?.exitCode === null && child.signalCode === null) {
+    child.kill('SIGKILL');
+  }
+  child = undefined;
+
+  if (sandbox) {
+    await fs.rm(sandbox, { recursive: true, force: true });
+    sandbox = undefined;
+  }
+});
+
+/** Resolves once the server has completed the handshake and started its services. */
+async function handshakeAndWaitForReady(proc: ChildProcessWithoutNullStreams): Promise<void> {
+  const initialize = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'lifecycle-test', version: '1.0.0' },
+    },
+  };
+
+  return new Promise<void>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let initialized = false;
+
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+
+      // Answering `initialize` means the server is live; the notification then
+      // triggers the post-handshake block that pins the event loop.
+      if (!initialized && stdout.includes('"id":1')) {
+        initialized = true;
+        proc.stdin.write(
+          `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`,
+        );
+      }
+
+      if (stdout.includes(READY_LOG)) {
+        resolve();
+      }
+    });
+
+    proc.once('exit', (code, signal) => {
+      reject(
+        new Error(
+          `server exited during handshake (code=${code}, signal=${signal})\nstderr:\n${stderr}`,
+        ),
+      );
+    });
+
+    proc.stdin.write(`${JSON.stringify(initialize)}\n`);
+  });
+}
+
+/** Resolves with the exit code, or rejects if the process outlives the budget. */
+async function waitForExit(proc: ChildProcessWithoutNullStreams, ms: number): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`process still running ${ms}ms after stdin closed — orphan regression`));
+    }, ms);
+
+    proc.once('exit', (code) => {
+      clearTimeout(timer);
+      resolve(code ?? -1);
+    });
+  });
+}
+
+describe('stdio server lifecycle', () => {
+  it(
+    'exits when the client closes stdin',
+    async () => {
+      sandbox = await fs.mkdtemp(path.join(os.tmpdir(), 'email-mcp-lifecycle-'));
+
+      child = spawn(process.execPath, ['--import', 'tsx', ENTRY, 'stdio'], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          // Confine every read and write to the sandbox, so the test cannot see
+          // a developer's real config or touch a real scheduled-mail queue.
+          XDG_CONFIG_HOME: path.join(sandbox, 'config'),
+          XDG_DATA_HOME: path.join(sandbox, 'data'),
+          XDG_STATE_HOME: path.join(sandbox, 'state'),
+          // Only satisfy config validation. No tool is invoked and the watcher is
+          // off, so no socket is ever opened to these hosts.
+          MCP_EMAIL_ADDRESS: 'test@example.invalid',
+          MCP_EMAIL_PASSWORD: 'unused',
+          MCP_EMAIL_IMAP_HOST: 'imap.example.invalid',
+          MCP_EMAIL_SMTP_HOST: 'smtp.example.invalid',
+          MCP_EMAIL_WATCHER_ENABLED: 'false',
+        },
+      });
+
+      await handshakeAndWaitForReady(child);
+
+      child.stdin.end();
+
+      await expect(waitForExit(child, LIFECYCLE_BUDGET_MS)).resolves.toBe(0);
+    },
+    LIFECYCLE_BUDGET_MS * 2,
+  );
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,6 +150,14 @@ async function runServer(): Promise<void> {
 
         await watcherService.start();
 
+        // Same reason as the guard below, but this await is the wider window: a
+        // watcher that finishes starting after shutdown holds IDLE sockets that
+        // the already-completed stop() never saw. stop() is idempotent.
+        if (shuttingDown) {
+          await watcherService.stop();
+          return;
+        }
+
         await mcpLog('info', 'server', 'Email MCP server started');
 
         // Check for overdue scheduled emails on startup
@@ -187,9 +195,12 @@ async function runServer(): Promise<void> {
 
   // Graceful shutdown
   //
-  // Per the MCP stdio lifecycle the client shuts us down by closing our stdin,
-  // and EOF is the only death signal that survives a SIGKILLed client — the
-  // kernel closes the pipe either way — and the only one Windows has, lacking
+  // The spec puts shutdown on the client: over stdio it SHOULD initiate it by
+  // "first, closing the input stream to the child process (the server)", then
+  // "waiting for the server to exit" before escalating to SIGTERM and SIGKILL
+  // (MCP basic/lifecycle, Shutdown). So EOF is the primary signal, not a
+  // fallback — and the only one that survives a SIGKILLed client, since the
+  // kernel closes the pipe either way, and the only one Windows has, lacking
   // POSIX signals. StdioServerTransport subscribes to 'data' and 'error' only,
   // so nothing observes EOF unless we listen for it here. Skipping that leaks an
   // immortal process on every client death that misses SIGTERM: the services

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,13 @@ import TemplateService from './services/template.service.js';
 import WatcherService from './services/watcher.service.js';
 import registerAllTools from './tools/register.js';
 
+/**
+ * How long a graceful shutdown may take before the process is forced down.
+ * Bounds the two goodbye round trips (SMTP QUIT, IMAP LOGOUT) over a slow WAN;
+ * past that, dropping the sockets beats leaking the process we are shutting down.
+ */
+const SHUTDOWN_GRACE_MS = 5_000;
+
 const HELP = `
 email-mcp — Email MCP Server (IMAP + SMTP)
 
@@ -128,6 +135,7 @@ async function runServer(): Promise<void> {
   // --------------------------------------------------------------------------
 
   let schedulerInterval: ReturnType<typeof setInterval> | undefined;
+  let shuttingDown = false;
 
   const lowLevelServer = server.server;
 
@@ -154,6 +162,12 @@ async function runServer(): Promise<void> {
           // Non-fatal: scheduler check failure shouldn't prevent server start
         }
 
+        // A client can vanish mid-startup — reconnect storms do it routinely, and
+        // this block sits behind two awaits. Arming the tick after shutdown already
+        // ran would leave a ref'd handle nothing clears: the very orphan the
+        // shutdown path below exists to prevent.
+        if (shuttingDown) return;
+
         // Periodic scheduler check every 60 seconds
         schedulerInterval = setInterval(async () => {
           try {
@@ -172,7 +186,32 @@ async function runServer(): Promise<void> {
   };
 
   // Graceful shutdown
-  const shutdown = async () => {
+  //
+  // Per the MCP stdio lifecycle the client shuts us down by closing our stdin,
+  // and EOF is the only death signal that survives a SIGKILLed client — the
+  // kernel closes the pipe either way — and the only one Windows has, lacking
+  // POSIX signals. StdioServerTransport subscribes to 'data' and 'error' only,
+  // so nothing observes EOF unless we listen for it here. Skipping that leaks an
+  // immortal process on every client death that misses SIGTERM: the services
+  // below hold ref'd handles (scheduler tick, hooks rate-limit timer, IMAP IDLE
+  // sockets), so the event loop never drains by itself.
+  const shutdown = async (reason: string) => {
+    // EOF, 'close' and a signal routinely arrive together.
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    // A hung QUIT/LOGOUT must not resurrect the orphan this exists to prevent.
+    // The valve is unref'd or it becomes the handle it was meant to release.
+    setTimeout(() => {
+      process.stderr.write(`[email-mcp] shutdown (${reason}) timed out — forcing exit\n`);
+      // `process.exitCode` is the house style, but it only takes effect once the
+      // loop drains, and a hung shutdown is exactly the case where it will not.
+      // Throwing would surface as an uncaught exception from a timer rather than
+      // a stop. Forcing the exit is what this valve is for.
+      // eslint-disable-next-line n/no-process-exit
+      process.exit(1);
+    }, SHUTDOWN_GRACE_MS).unref();
+
     if (schedulerInterval) clearInterval(schedulerInterval);
     hooksService.stop();
     await watcherService.stop();
@@ -180,8 +219,19 @@ async function runServer(): Promise<void> {
     await server.close();
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  // eslint-disable-next-line no-void
+  const requestShutdown = (reason: string): void => void shutdown(reason);
+
+  // Listening for 'data' here would switch stdin to flowing mode and eat protocol
+  // bytes from under the SDK; 'end'/'close' leave the stream's mode untouched.
+  process.stdin.once('end', () => requestShutdown('stdin EOF'));
+  process.stdin.once('close', () => requestShutdown('stdin closed'));
+  // Redundant while the SDK never fires it, and the idiomatic path once it does.
+  transport.onclose = () => requestShutdown('transport closed');
+
+  process.on('SIGINT', requestShutdown);
+  process.on('SIGTERM', requestShutdown);
+  process.on('SIGHUP', requestShutdown);
 }
 
 async function readBody(req: IncomingMessage): Promise<Buffer> {


### PR DESCRIPTION
## Description

Fixes #60 — the stdio server never exited when the client closed its stdin, so every client death that skipped `SIGTERM` (closed terminal, `SIGKILL`, crash, MCP reconnect) left an immortal process reparented to `launchd`/`init`. I found 232 of them on one workstation after 7 days of uptime, holding 5.2 GB RSS and pushing the machine into 13.3 GB of swap.

The spec is explicit about whose job this is. From `basic/lifecycle`, Shutdown:

> For the stdio transport, the client **SHOULD** initiate shutdown by:
> 1. First, closing the input stream to the child process (the server)
> 2. Waiting for the server to exit, or sending `SIGTERM` if the server does not exit within a reasonable time
> 3. Sending `SIGKILL` if the server does not exit within a reasonable time after `SIGTERM`

"Waiting for the server to exit" is the part this package could not honour. Three things had to coincide, and all three did:

1. `StdioServerTransport` subscribes to `'data'` and `'error'` only, so EOF on stdin raises no event and `transport.onclose` never fires in stdio mode.
2. Nothing in `runServer` listened for it either — `transport.onclose` was wired on the HTTP path only.
3. The scheduler tick, the hooks rate-limit timer and IMAP IDLE sockets are all ref'd handles, so the event loop never drained by itself.

This PR shuts down on stdin `'end'`/`'close'` and on `transport.onclose`, adds `SIGHUP` beside the existing signals, and makes `shutdown` idempotent because those triggers routinely arrive together. A grace timer forces the exit if a goodbye round trip hangs, so a stuck `QUIT`/`LOGOUT` cannot resurrect the orphan.

It also guards the post-handshake block, at both of its `await` boundaries. That block sits behind two `await`s, so a client disconnecting mid-startup could arm the scheduler tick *after* `shutdown` had already run — a ref'd handle nothing clears. The new test caught this; without the guard it fails with exit code 1 from the grace timer instead of hanging. It is pre-existing (a `SIGTERM` during startup did the same) but only becomes observable once the server can exit at all.

A second review pass found the same shape one `await` earlier, at `watcherService.start()`: a watcher finishing its start after `shutdown` has run holds IMAP IDLE sockets the completed `stop()` never saw, so the loop stays pinned and the grace timer forces exit 1 rather than a clean stop. With the watcher enabled that is not an edge case — reconnect storms hit precisely that window. `stop()` is idempotent, so the guard re-runs it and bails.

## Reproduction

Minimal, no account needed — this isolates the mechanism:

```js
// a.mjs — the listener shape StdioServerTransport installs
process.stdin.on('data', () => {}); process.stdin.on('error', () => {});
// b.mjs — same, plus the scheduler interval
process.stdin.on('data', () => {}); process.stdin.on('error', () => {}); setInterval(() => {}, 60_000);
```

`printf 'x\n' | node a.mjs` exits on its own; `printf 'x\n' | node b.mjs` never does.

For a control: `chrome-devtools-mcp` runs through the same `npx` launcher and the same SDK on the same machine and left zero orphans over those 7 days. The launcher and the SDK are not the differentiator; the event-loop-pinning handle is.

## Decisions worth a second opinion

- **Detection rather than `.unref()`.** Unref'ing the scheduler interval alone fixes nothing, because `hooks.service.ts` (`rateResetTimer`) and IMAP IDLE sockets still pin the loop. Unref'ing all of them would touch three services and still leave the loop pinned by any handle added later. `shutdown()` already stops every one of them, so the missing piece was only ever the trigger. Happy to add `.unref()` as belt-and-braces if you prefer it.
- **`process.exit` in the grace timer** needs an `n/no-process-exit` disable. `process.exitCode` is the house style, but it only takes effect once the loop drains — and a hung shutdown is exactly the case where it will not. The reasoning is in a comment at the call site.
- **No `'data'` listener on stdin**, deliberately: it would switch the stream to flowing mode and consume protocol bytes out from under the SDK. `'end'`/`'close'` leave the mode untouched.
- **`transport.onclose` is redundant today** and wired anyway, so this becomes the idiomatic path if the SDK ever emits it. Worth knowing: modelcontextprotocol/typescript-sdk#2002 reports the SDK-side gap and has had three competing PRs open since May with none merged. Fixing the SDK alone would not have fixed this package anyway, given point 2 above.

## Test

`src/main.lifecycle.test.ts` spawns the server as a real child process — the defect is the event loop failing to drain, which is unobservable in-process. It completes the handshake, closes stdin, and asserts a clean exit. Everything is confined to a temp dir via `XDG_*`, so it cannot see a developer's real config or touch a real scheduled-mail queue, and `afterEach` kills the child — a test about leaked processes should not leak one.

Verified red before / green after by stashing the `src/main.ts` change:

```
without the fix: × exits when the client closes stdin
                 Caused by: Error: process still running 20000ms after stdin closed — orphan regression
with the fix:    ✓ exits when the client closes stdin  4211ms
```

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Checklist

- [x] My code follows the project's code style (Biome formatter + ESLint linter)
- [x] I have run `pnpm check` and it passes
- [x] I have run `pnpm typecheck` and it passes
- [x] I have added tests that prove my fix/feature works — `pnpm test`: 151 passed / 16 files
- [ ] I have updated documentation — no user-facing behaviour change to document; say the word if you want a CHANGELOG entry
- [x] My changes generate no new warnings

One behavioural consequence worth stating explicitly: a server spawned with `stdio: 'ignore'` gets `/dev/null` as stdin and therefore an immediate EOF, so it now exits at once. For a stdio transport that seems correct — such a server has no client and can never receive a request — but it is a change from today's silent hang.
