### PR TITLE
fix(imap): handle cached client error and close events safely

### DIFF
--- a/src/connections/manager.test.ts
+++ b/src/connections/manager.test.ts
@@ -1,0 +1,96 @@
+import type { AccountConfig } from '../types/index.js';
+import ConnectionManager from './manager.js';
+
+type MockListener = (...args: unknown[]) => void;
+type MockClient = {
+  usable: boolean;
+  connect: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+  on: (event: string, listener: MockListener) => MockClient;
+  emit: (event: string, ...args: unknown[]) => boolean;
+};
+
+const imapInstances = vi.hoisted(() => [] as MockClient[]);
+
+vi.mock('imapflow', () => {
+  class MockImapFlow {
+    usable = true;
+    connect = vi.fn().mockResolvedValue(undefined);
+    close = vi.fn();
+    logout = vi.fn().mockResolvedValue(undefined);
+    private listeners = new Map<string, MockListener[]>();
+
+    constructor(_options: unknown) {
+      imapInstances.push(this as unknown as MockClient);
+    }
+
+    on(event: string, listener: MockListener) {
+      const listeners = this.listeners.get(event) ?? [];
+      listeners.push(listener);
+      this.listeners.set(event, listeners);
+      return this;
+    }
+
+    emit(event: string, ...args: unknown[]) {
+      const listeners = this.listeners.get(event) ?? [];
+      for (const listener of listeners) listener(...args);
+      if (event === 'error' && listeners.length === 0) throw args[0];
+      return listeners.length > 0;
+    }
+  }
+
+  return { ImapFlow: MockImapFlow };
+});
+
+vi.mock('../logging.js', () => ({ mcpLog: vi.fn().mockResolvedValue(undefined) }));
+
+const account: AccountConfig = {
+  name: 'test',
+  email: 'test@example.com',
+  username: 'test@example.com',
+  password: 'password',
+  imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
+  smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+};
+
+describe('ConnectionManager IMAP lifecycle', () => {
+  beforeEach(() => {
+    imapInstances.length = 0;
+  });
+
+  it('handles ImapFlow error events and reconnects on the next request', async () => {
+    const manager = new ConnectionManager([account]);
+    const first = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    expect(() => first.emit('error', new Error('Socket timeout'))).not.toThrow();
+
+    const second = (await manager.getImapClient('test')) as unknown as MockClient;
+    expect(second).not.toBe(first);
+    expect(imapInstances).toHaveLength(2);
+  });
+
+  it('does not let a late error from a stale client invalidate its replacement', async () => {
+    const manager = new ConnectionManager([account]);
+    const first = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    first.emit('error', new Error('Connection lost'));
+    const replacement = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    first.emit('error', new Error('Late stale error'));
+    const current = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    expect(current).toBe(replacement);
+    expect(imapInstances).toHaveLength(2);
+  });
+
+  it('invalidates the cached client when it closes', async () => {
+    const manager = new ConnectionManager([account]);
+    const first = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    first.emit('close');
+    const second = (await manager.getImapClient('test')) as unknown as MockClient;
+
+    expect(second).not.toBe(first);
+  });
+});

--- a/src/connections/manager.ts
+++ b/src/connections/manager.ts
@@ -58,6 +58,25 @@ export default class ConnectionManager implements IConnectionManager {
   // IMAP
   // -------------------------------------------------------------------------
 
+  private registerImapLifecycle(accountName: string, client: ImapFlow): void {
+    const invalidateIfCurrent = () => {
+      if (this.imapClients.get(accountName) === client) {
+        this.imapClients.delete(accountName);
+      }
+    };
+
+    client.on('error', (err) => {
+      invalidateIfCurrent();
+      void mcpLog(
+        'error',
+        'imap',
+        `Connection error for "${accountName}": ${err instanceof Error ? err.message : String(err)}`,
+      ).catch(() => undefined);
+    });
+
+    client.on('close', invalidateIfCurrent);
+  }
+
   async getImapClient(accountName: string): Promise<ImapFlow> {
     const existing = this.imapClients.get(accountName);
     if (existing?.usable) {
@@ -96,6 +115,7 @@ export default class ConnectionManager implements IConnectionManager {
       logger: false,
     });
 
+    this.registerImapLifecycle(accountName, client);
     await client.connect();
     await mcpLog(
       'info',
@@ -224,6 +244,7 @@ export default class ConnectionManager implements IConnectionManager {
         auth,
         logger: false,
       });
+      client.on('error', () => {});
       await client.connect();
 
       const mailboxes = await client.list();


### PR DESCRIPTION
## Summary

Handle ImapFlow `error` and `close` events for cached IMAP clients so connection failures cannot become unhandled EventEmitter errors and stale client events cannot invalidate a newer replacement connection.

### What changes

- attach an `error` listener to each cached ImapFlow client
- log the connection error and invalidate that cached client so the next request reconnects
- attach a `close` listener to invalidate a disconnected cached client
- invalidate the cache only when the event belongs to the client instance that is **currently** cached for that account
- add an error listener to the short-lived IMAP discovery client as well, preventing EventEmitter `error` from escaping that path
- add focused tests for current-client error, current-client close and stale-client events

## Why

Node treats an emitted EventEmitter `error` without a listener as an uncaught exception. A long-running IMAP connection can encounter socket/network failures, so the connection manager needs to own that event lifecycle explicitly.

The identity check is important: an old client may emit `close` or `error` after a replacement has already been cached. Such a stale event must not remove the new healthy client.

## Validation

Validated from repository base `99ce431aa81dd4cafc2879bd35b6ee3acd0f2d74` on Node 24 as part of the combined production candidate:

- full test suite: **157/157 tests passed**
- `tsc --noEmit`: passed
- Biome check across `src`: passed
- production build: passed
- Docker image build: passed
- deployed together with the separately scoped HTTP session lifecycle fix and verified through the normal MCP health path with IMAP and SMTP connected

This PR is intentionally separate from the HTTP session/heap lifecycle fix in #63.