### PR TITLE
feat(attachments): save downloads to configured download dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,13 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
-# Create config directory for volume mount
-RUN mkdir -p /home/node/.config/email-mcp && chown -R node:node /home/node/.config
+# Create config directory for volume mount and default attachment download path
+RUN mkdir -p /home/node/.config/email-mcp /workspace/paperless \
+  && chown -R node:node /home/node/.config /workspace/paperless
 
 ENV NODE_ENV=production
+# Optional default; override with MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR at runtime
+ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/workspace/paperless
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,12 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
 # Create config directory for volume mount and default attachment download path
-RUN mkdir -p /home/node/.config/email-mcp /workspace/paperless \
-  && chown -R node:node /home/node/.config /workspace/paperless
+RUN mkdir -p /home/node/.config/email-mcp /data/attachments \
+  && chown -R node:node /home/node/.config /data/attachments
 
 ENV NODE_ENV=production
 # Optional default; override with MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR at runtime
-ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/workspace/paperless
+ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/data/attachments
 
 USER node
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -35,10 +35,12 @@ COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
-# Create config directory for volume mount
-RUN mkdir -p /home/node/.config/email-mcp && chown -R node:node /home/node/.config
+# Create config directory for volume mount and default attachment download path
+RUN mkdir -p /home/node/.config/email-mcp /workspace/paperless \
+  && chown -R node:node /home/node/.config /workspace/paperless
 
 ENV NODE_ENV=production
+ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/workspace/paperless
 
 USER node
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -36,11 +36,11 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
 
 # Create config directory for volume mount and default attachment download path
-RUN mkdir -p /home/node/.config/email-mcp /workspace/paperless \
-  && chown -R node:node /home/node/.config /workspace/paperless
+RUN mkdir -p /home/node/.config/email-mcp /data/attachments \
+  && chown -R node:node /home/node/.config /data/attachments
 
 ENV NODE_ENV=production
-ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/workspace/paperless
+ENV MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR=/data/attachments
 
 USER node
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,70 @@ For single-account setups (overrides config file):
 | `MCP_EMAIL_SMTP_POOL_MAX_CONNECTIONS` | `1` | Max pooled SMTP connections |
 | `MCP_EMAIL_SMTP_POOL_MAX_MESSAGES` | `100` | Max messages per pooled connection |
 | `MCP_EMAIL_RATE_LIMIT` | `10` | Max sends per minute |
+| `MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR` | — | Directory for `download_attachment` with `save_to_download_dir=true`. Alias: `EMAIL_ATTACHMENT_DOWNLOAD_DIR` |
+| `MCP_EMAIL_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS` | `pdf,png,jpg,jpeg,webp,tiff,txt,md,doc,docx,odt,xls,xlsx,csv` | Comma-separated allowlist for download-dir saves |
+| `MCP_EMAIL_ATTACHMENT_DOWNLOAD_MAX_BYTES` | `26214400` | Max attachment size for download-dir writes (25 MB) |
+
+### Attachment download directory
+
+By default `download_attachment` returns base64 (≤5 MB). For larger files — or to hand a document to another MCP without stuffing the model context — set an attachment download directory and call the tool with `save_to_download_dir=true`:
+
+```json
+{
+  "account": "default",
+  "id": "42",
+  "filename": "invoice.pdf",
+  "save_to_download_dir": true,
+  "save_as": "invoice.pdf"
+}
+```
+
+Response (no base64):
+
+```json
+{
+  "filename": "invoice.pdf",
+  "mimeType": "application/pdf",
+  "size": 204800,
+  "savedTo": "/workspace/paperless/invoice.pdf"
+}
+```
+
+Safeguards:
+
+- **Configured directory only** — agents cannot pick an arbitrary path; `save_as` must be a basename
+- **Extension allowlist** — reject downloads whose final name is not on `MCP_EMAIL_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS`
+- **Path jail** — separators, `..`, and absolute paths are rejected; writes use temp file + rename (replaces symlinks rather than writing through them)
+
+#### Sharing the download directory with another MCP server
+
+Mount the same volume into email-mcp and e.g. [PaperlessMCP](https://github.com/barryw/PaperlessMCP) (which calls its shared dir an “outbox”), then upload with `paperless_documents_upload_from_path` using the `savedTo` path:
+
+```yaml
+services:
+  email-mcp:
+    image: ghcr.io/codefuturist/email-mcp:latest
+    command: ["http", "8080"]
+    environment:
+      MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR: /workspace/paperless
+      # …IMAP/SMTP env…
+    volumes:
+      - paperless-outbox:/workspace/paperless
+    ports:
+      - "8081:8080"
+
+  paperless-mcp:
+    image: ghcr.io/barryw/paperlessmcp:latest
+    environment:
+      PAPERLESS_OUTBOX_DIR: /workspace/paperless
+    volumes:
+      - paperless-outbox:/workspace/paperless
+
+volumes:
+  paperless-outbox:
+```
+
+The download directory must be writable by the container user (`node`, uid typically 1000).
 
 ### Email Scheduling
 
@@ -655,7 +719,7 @@ Features:
 | `get_emails` | Fetch full content of multiple emails in a single call (max 20) |
 | `get_email_status` | Get read/flag/label state of an email without fetching the body |
 | `search_emails` | Search by keyword across subject, sender, and body |
-| `download_attachment` | Download an email attachment by filename |
+| `download_attachment` | Download an email attachment by filename (base64, or `save_to_download_dir=true` for path-only) |
 | `find_email_folder` | Discover the real folder(s) an email resides in (resolves virtual folders) |
 | `extract_contacts` | Extract unique contacts from recent email headers |
 | `get_thread` | Reconstruct a conversation thread via References/In-Reply-To |

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ Response (no base64):
   "filename": "invoice.pdf",
   "mimeType": "application/pdf",
   "size": 204800,
-  "savedTo": "/workspace/paperless/invoice.pdf"
+  "savedTo": "/data/attachments/invoice.pdf"
 }
 ```
 
@@ -478,7 +478,7 @@ Safeguards:
 
 #### Sharing the download directory with another MCP server
 
-Mount the same volume into email-mcp and e.g. [PaperlessMCP](https://github.com/barryw/PaperlessMCP) (which calls its shared dir an “outbox”), then upload with `paperless_documents_upload_from_path` using the `savedTo` path:
+Mount the same volume into email-mcp and any other tool that reads files by path. Use the `savedTo` value from `download_attachment` as the path on that shared volume:
 
 ```yaml
 services:
@@ -486,22 +486,20 @@ services:
     image: ghcr.io/codefuturist/email-mcp:latest
     command: ["http", "8080"]
     environment:
-      MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR: /workspace/paperless
+      MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR: /data/attachments
       # …IMAP/SMTP env…
     volumes:
-      - paperless-outbox:/workspace/paperless
+      - attachments:/data/attachments
     ports:
       - "8081:8080"
 
-  paperless-mcp:
-    image: ghcr.io/barryw/paperlessmcp:latest
-    environment:
-      PAPERLESS_OUTBOX_DIR: /workspace/paperless
+  other-mcp:
+    image: example/other-mcp:latest
     volumes:
-      - paperless-outbox:/workspace/paperless
+      - attachments:/data/attachments
 
 volumes:
-  paperless-outbox:
+  attachments:
 ```
 
 The download directory must be writable by the container user (`node`, uid typically 1000).

--- a/src/cli/config-commands.ts
+++ b/src/cli/config-commands.ts
@@ -53,7 +53,18 @@ async function showConfig(): Promise<void> {
   console.log(`Config file: ${CONFIG_FILE}\n`);
   console.log(`[settings]`);
   console.log(`  rate_limit = ${config.settings.rateLimit}`);
-  console.log(`  read_only  = ${config.settings.readOnly}\n`);
+  console.log(`  read_only  = ${config.settings.readOnly}`);
+  const { attachmentDownload } = config.settings;
+  if (attachmentDownload.dir) {
+    console.log(`  attachment_download.dir = ${attachmentDownload.dir}`);
+    console.log(
+      `  attachment_download.allowed_extensions = ${attachmentDownload.allowedExtensions.join(',')}`,
+    );
+    console.log(`  attachment_download.max_bytes = ${attachmentDownload.maxBytes}`);
+  } else {
+    console.log(`  attachment_download.dir = (unset)`);
+  }
+  console.log('');
 
   config.accounts.forEach((account) => {
     console.log(`[accounts.${account.name}]`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -373,7 +373,7 @@ read_only = false  # set to true to disable all write operations
 
 # Optional attachment download dir (also: MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR)
 # [settings.attachment_download]
-# dir = "/workspace/paperless"
+# dir = "/data/attachments"
 # allowed_extensions = ["pdf", "png", "jpg", "jpeg", "webp", "tiff", "txt", "md", "doc", "docx", "odt", "xls", "xlsx", "csv"]
 # max_bytes = 26214400
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,10 +8,59 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
-import type { AccountConfig, AppConfig, HookRule, OAuth2Config } from '../types/index.js';
+import {
+  DEFAULT_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS,
+  DEFAULT_ATTACHMENT_DOWNLOAD_MAX_BYTES,
+  parseExtensionAllowlist,
+} from '../safety/attachment-download.js';
+import type {
+  AccountConfig,
+  AppConfig,
+  AttachmentDownloadConfig,
+  HookRule,
+  OAuth2Config,
+} from '../types/index.js';
 import type { RawAccountConfig, RawAppConfig } from './schema.js';
 import { AppConfigFileSchema } from './schema.js';
 import { CONFIG_FILE, xdg } from './xdg.js';
+
+// ---------------------------------------------------------------------------
+// Attachment download dir env helpers (also overlay onto TOML-loaded config)
+// ---------------------------------------------------------------------------
+
+function readAttachmentDownloadDirFromEnv(): string | undefined {
+  const value =
+    process.env.MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR ?? process.env.EMAIL_ATTACHMENT_DOWNLOAD_DIR;
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function attachmentDownloadFromEnvOrRaw(
+  raw: RawAppConfig['settings']['attachment_download'] | undefined,
+): AttachmentDownloadConfig {
+  const dir = readAttachmentDownloadDirFromEnv() ?? raw?.dir;
+  const envExt = process.env.MCP_EMAIL_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS;
+  let allowedExtensions: string[];
+  if (envExt !== undefined) {
+    allowedExtensions = parseExtensionAllowlist(envExt);
+  } else if (raw?.allowed_extensions !== undefined) {
+    allowedExtensions = raw.allowed_extensions.map((e) => e.toLowerCase().replace(/^\./, ''));
+  } else {
+    allowedExtensions = [...DEFAULT_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS];
+  }
+  const envMax = process.env.MCP_EMAIL_ATTACHMENT_DOWNLOAD_MAX_BYTES;
+  const maxBytes =
+    envMax !== undefined
+      ? parseInt(envMax, 10)
+      : (raw?.max_bytes ?? DEFAULT_ATTACHMENT_DOWNLOAD_MAX_BYTES);
+
+  return {
+    dir,
+    allowedExtensions,
+    maxBytes:
+      Number.isFinite(maxBytes) && maxBytes > 0 ? maxBytes : DEFAULT_ATTACHMENT_DOWNLOAD_MAX_BYTES,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Environment variable loader (single-account quick setup)
@@ -46,6 +95,17 @@ function loadFromEnv(): RawAppConfig | null {
     settings: {
       rate_limit: parseInt(process.env.MCP_EMAIL_RATE_LIMIT ?? '10', 10),
       read_only: process.env.MCP_EMAIL_READ_ONLY === 'true',
+      attachment_download: {
+        dir: readAttachmentDownloadDirFromEnv(),
+        allowed_extensions: parseExtensionAllowlist(
+          process.env.MCP_EMAIL_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS,
+        ),
+        max_bytes: parseInt(
+          process.env.MCP_EMAIL_ATTACHMENT_DOWNLOAD_MAX_BYTES ??
+            String(DEFAULT_ATTACHMENT_DOWNLOAD_MAX_BYTES),
+          10,
+        ),
+      },
       watcher: {
         enabled: process.env.MCP_EMAIL_WATCHER_ENABLED === 'true',
         folders: (process.env.MCP_EMAIL_WATCHER_FOLDERS ?? 'INBOX')
@@ -210,6 +270,7 @@ function normalizeConfig(raw: RawAppConfig): AppConfig {
     settings: {
       rateLimit: raw.settings.rate_limit,
       readOnly: raw.settings.read_only,
+      attachmentDownload: attachmentDownloadFromEnvOrRaw(raw.settings.attachment_download),
       watcher: {
         enabled: raw.settings.watcher.enabled,
         folders: raw.settings.watcher.folders,
@@ -309,6 +370,12 @@ export function generateTemplate(): string {
 [settings]
 rate_limit = 10  # max emails per minute per account
 read_only = false  # set to true to disable all write operations
+
+# Optional attachment download dir (also: MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR)
+# [settings.attachment_download]
+# dir = "/workspace/paperless"
+# allowed_extensions = ["pdf", "png", "jpg", "jpeg", "webp", "tiff", "txt", "md", "doc", "docx", "odt", "xls", "xlsx", "csv"]
+# max_bytes = 26214400
 
 # [settings.watcher]
 # enabled = false        # enable IMAP IDLE real-time monitoring

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -115,9 +115,16 @@ export const HooksConfigSchema = z.object({
   calendar_confirm: z.boolean().default(true),
 });
 
+export const AttachmentDownloadConfigSchema = z.object({
+  dir: z.string().min(1).optional(),
+  allowed_extensions: z.array(z.string().min(1)).optional(),
+  max_bytes: z.number().int().min(1).optional(),
+});
+
 export const SettingsSchema = z.object({
   rate_limit: z.number().int().min(1).default(10),
   read_only: z.boolean().default(false),
+  attachment_download: AttachmentDownloadConfigSchema.optional(),
   watcher: WatcherConfigSchema.default({
     enabled: false,
     folders: ['INBOX'],

--- a/src/safety/attachment-download.test.ts
+++ b/src/safety/attachment-download.test.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  assertAllowedExtension,
+  assertSafeDownloadBasename,
+  parseExtensionAllowlist,
+  resolveAttachmentDownloadPath,
+  sanitizeAttachmentBasename,
+  writeDownloadFileAtomic,
+} from './attachment-download.js';
+
+describe('assertSafeDownloadBasename', () => {
+  it('accepts a simple basename', () => {
+    expect(assertSafeDownloadBasename('invoice.pdf')).toBe('invoice.pdf');
+  });
+
+  it('trims whitespace', () => {
+    expect(assertSafeDownloadBasename('  report.docx  ')).toBe('report.docx');
+  });
+
+  it('rejects empty', () => {
+    expect(() => assertSafeDownloadBasename('')).toThrow('must not be empty');
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => assertSafeDownloadBasename('/tmp/evil.pdf')).toThrow('absolute');
+  });
+
+  it('rejects path separators', () => {
+    expect(() => assertSafeDownloadBasename('subdir/file.pdf')).toThrow('path separators');
+    expect(() => assertSafeDownloadBasename('subdir\\file.pdf')).toThrow('path separators');
+  });
+
+  it('rejects .. and .', () => {
+    expect(() => assertSafeDownloadBasename('..')).toThrow();
+    expect(() => assertSafeDownloadBasename('.')).toThrow();
+  });
+
+  it('rejects NUL', () => {
+    expect(() => assertSafeDownloadBasename('a\0b.pdf')).toThrow('NUL');
+  });
+});
+
+describe('sanitizeAttachmentBasename', () => {
+  it('strips directory components', () => {
+    expect(sanitizeAttachmentBasename('../../etc/passwd.pdf')).toBe('passwd.pdf');
+  });
+
+  it('replaces unsafe characters', () => {
+    expect(sanitizeAttachmentBasename('my:file*.pdf')).toBe('my_file_.pdf');
+  });
+});
+
+describe('assertAllowedExtension', () => {
+  const allow = ['pdf', 'png'];
+
+  it('allows listed extensions case-insensitively', () => {
+    expect(() => assertAllowedExtension('a.PDF', allow)).not.toThrow();
+    expect(() => assertAllowedExtension('a.png', allow)).not.toThrow();
+  });
+
+  it('rejects unlisted extensions', () => {
+    expect(() => assertAllowedExtension('a.exe', allow)).toThrow('not allowed');
+  });
+
+  it('rejects missing extension', () => {
+    expect(() => assertAllowedExtension('noext', allow)).toThrow('not allowed');
+  });
+});
+
+describe('parseExtensionAllowlist', () => {
+  it('returns defaults for empty input', () => {
+    expect(parseExtensionAllowlist(undefined)).toContain('pdf');
+    expect(parseExtensionAllowlist('')).toContain('pdf');
+  });
+
+  it('parses comma-separated list', () => {
+    expect(parseExtensionAllowlist('.PDF, png ,DOCX')).toEqual(['pdf', 'png', 'docx']);
+  });
+});
+
+describe('resolveAttachmentDownloadPath + writeDownloadFileAtomic', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'email-mcp-attach-dl-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('resolves under the download dir root', async () => {
+    const target = await resolveAttachmentDownloadPath(tmpRoot, 'doc.pdf');
+    expect(target).toBe(path.join(await fs.realpath(tmpRoot), 'doc.pdf'));
+  });
+
+  it('writes atomically and replaces a symlink destination', async () => {
+    const outside = path.join(tmpRoot, 'outside.txt');
+    await fs.writeFile(outside, 'secret');
+
+    const linkPath = path.join(tmpRoot, 'link.pdf');
+    await fs.symlink(outside, linkPath);
+
+    const target = await resolveAttachmentDownloadPath(tmpRoot, 'link.pdf');
+    await writeDownloadFileAtomic(target, Buffer.from('safe-content'));
+
+    const linkStat = await fs.lstat(target);
+    expect(linkStat.isSymbolicLink()).toBe(false);
+    expect(await fs.readFile(target, 'utf8')).toBe('safe-content');
+    expect(await fs.readFile(outside, 'utf8')).toBe('secret');
+  });
+
+  it('rejects escape attempts via basename validation before resolve', async () => {
+    await expect(resolveAttachmentDownloadPath(tmpRoot, '../escape.pdf')).rejects.toThrow(
+      'path separators',
+    );
+  });
+});

--- a/src/safety/attachment-download.ts
+++ b/src/safety/attachment-download.ts
@@ -1,0 +1,133 @@
+/**
+ * Path-safe attachment download directory helpers.
+ *
+ * Downloads are confined to a server-configured directory. Agents may only
+ * supply a basename — never an absolute or relative path.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+/** Default extensions when the download dir is enabled and no allowlist is set. */
+export const DEFAULT_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS = [
+  'pdf',
+  'png',
+  'jpg',
+  'jpeg',
+  'webp',
+  'tiff',
+  'txt',
+  'md',
+  'doc',
+  'docx',
+  'odt',
+  'xls',
+  'xlsx',
+  'csv',
+] as const;
+
+export const DEFAULT_ATTACHMENT_DOWNLOAD_MAX_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Validate that `name` is a single path segment (basename only).
+ * Rejects empty names, absolute paths, separators, `.` / `..`, and NULs.
+ */
+export function assertSafeDownloadBasename(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Download filename must not be empty');
+  }
+  if (trimmed.includes('\0')) {
+    throw new Error('Download filename must not contain NUL characters');
+  }
+  if (path.isAbsolute(trimmed)) {
+    throw new Error('Download filename must be a basename, not an absolute path');
+  }
+  if (trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error('Download filename must not contain path separators');
+  }
+  if (trimmed === '.' || trimmed === '..') {
+    throw new Error('Download filename must not be "." or ".."');
+  }
+  const base = path.basename(trimmed);
+  if (base !== trimmed) {
+    throw new Error('Download filename must be a basename');
+  }
+  return base;
+}
+
+/**
+ * Derive a safe basename from an attachment filename (strips paths / unsafe chars).
+ */
+export function sanitizeAttachmentBasename(filename: string): string {
+  const normalized = filename.replace(/\\/g, '/');
+  const base = path.basename(normalized);
+  const cleaned = base.replace(/[^\w.\- ()[\]]+/g, '_').replace(/^\.+/, '');
+  return assertSafeDownloadBasename(cleaned.length > 0 ? cleaned : 'attachment');
+}
+
+/**
+ * Ensure the file extension is on the allowlist (case-insensitive, leading dots ignored).
+ */
+export function assertAllowedExtension(filename: string, allowlist: readonly string[]): void {
+  const ext = path.extname(filename).slice(1).toLowerCase();
+  const normalized = allowlist.map((e) => e.toLowerCase().replace(/^\./, ''));
+  if (!ext || !normalized.includes(ext)) {
+    throw new Error(
+      `Extension ${ext ? `".${ext}"` : '(none)'} is not allowed for attachment downloads. ` +
+        `Allowed: ${normalized.join(', ')}`,
+    );
+  }
+}
+
+/**
+ * Resolve a basename under `downloadDir`, creating the directory if needed.
+ * Guarantees the final path cannot escape the download dir via `..` or separators.
+ */
+export async function resolveAttachmentDownloadPath(
+  downloadDir: string,
+  basename: string,
+): Promise<string> {
+  const safe = assertSafeDownloadBasename(basename);
+  await fs.mkdir(downloadDir, { recursive: true });
+  const rootResolved = await fs.realpath(downloadDir);
+  const target = path.resolve(rootResolved, safe);
+  const prefix = rootResolved.endsWith(path.sep) ? rootResolved : `${rootResolved}${path.sep}`;
+  if (!target.startsWith(prefix)) {
+    throw new Error('Resolved path escapes attachment download directory');
+  }
+  return target;
+}
+
+/**
+ * Write `content` to `targetPath` atomically via a temp file + rename.
+ * Rename replaces an existing file or symlink rather than writing through it.
+ */
+export async function writeDownloadFileAtomic(targetPath: string, content: Buffer): Promise<void> {
+  const dir = path.dirname(targetPath);
+  const tmp = path.join(dir, `.${path.basename(targetPath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await fs.writeFile(tmp, content, { flag: 'wx' });
+    await fs.rename(tmp, targetPath);
+  } catch (err) {
+    try {
+      await fs.unlink(tmp);
+    } catch {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
+}
+
+/**
+ * Parse a comma-separated extension allowlist from env / config.
+ */
+export function parseExtensionAllowlist(raw: string | undefined): string[] {
+  if (raw === undefined || raw.trim().length === 0) {
+    return [...DEFAULT_ATTACHMENT_DOWNLOAD_ALLOWED_EXTENSIONS];
+  }
+  return raw
+    .split(',')
+    .map((e) => e.trim().toLowerCase().replace(/^\./, ''))
+    .filter(Boolean);
+}

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -6,6 +6,13 @@
 
 import type { ImapFlow } from 'imapflow';
 import type { IConnectionManager } from '../connections/types.js';
+import {
+  assertAllowedExtension,
+  assertSafeDownloadBasename,
+  resolveAttachmentDownloadPath,
+  sanitizeAttachmentBasename,
+  writeDownloadFileAtomic,
+} from '../safety/attachment-download.js';
 import { sanitizeMailboxName, sanitizeSearchQuery } from '../safety/validation.js';
 import type {
   AttachmentMeta,
@@ -1125,6 +1132,36 @@ export default class ImapService {
     size: number;
     contentBase64: string;
   }> {
+    const result = await this.downloadAttachmentBuffer(
+      accountName,
+      emailId,
+      mailbox,
+      filename,
+      maxSizeBytes,
+    );
+    return {
+      filename: result.filename,
+      mimeType: result.mimeType,
+      size: result.size,
+      contentBase64: result.content.toString('base64'),
+    };
+  }
+
+  /**
+   * Download an attachment as a Buffer (no base64 encoding).
+   */
+  async downloadAttachmentBuffer(
+    accountName: string,
+    emailId: string,
+    mailbox: string,
+    filename: string,
+    maxSizeBytes = 5 * 1024 * 1024,
+  ): Promise<{
+    filename: string;
+    mimeType: string;
+    size: number;
+    content: Buffer;
+  }> {
     const client = await this.connections.getImapClient(accountName);
     const uid = parseInt(emailId, 10);
 
@@ -1181,11 +1218,56 @@ export default class ImapService {
         filename: attachment.filename,
         mimeType: attachment.mimeType,
         size: content.length,
-        contentBase64: content.toString('base64'),
+        content,
       };
     } finally {
       lock.release();
     }
+  }
+
+  /**
+   * Download an attachment into the configured attachment download directory.
+   * Returns metadata only — bytes never leave the filesystem as base64.
+   */
+  async downloadAttachmentToDownloadDir(
+    accountName: string,
+    emailId: string,
+    mailbox: string,
+    filename: string,
+    options: {
+      downloadDir: string;
+      allowedExtensions: readonly string[];
+      maxBytes: number;
+      saveAs?: string;
+    },
+  ): Promise<{
+    filename: string;
+    mimeType: string;
+    size: number;
+    savedTo: string;
+  }> {
+    const basename = options.saveAs
+      ? assertSafeDownloadBasename(options.saveAs)
+      : sanitizeAttachmentBasename(filename);
+    assertAllowedExtension(basename, options.allowedExtensions);
+
+    const downloaded = await this.downloadAttachmentBuffer(
+      accountName,
+      emailId,
+      mailbox,
+      filename,
+      options.maxBytes,
+    );
+
+    const target = await resolveAttachmentDownloadPath(options.downloadDir, basename);
+    await writeDownloadFileAtomic(target, downloaded.content);
+
+    return {
+      filename: basename,
+      mimeType: downloaded.mimeType,
+      size: downloaded.size,
+      savedTo: target,
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/src/tools/attachments.tool.ts
+++ b/src/tools/attachments.tool.ts
@@ -18,7 +18,7 @@ export default function registerAttachmentTools(
     'Download an email attachment by filename. First use get_email to see available attachments and their filenames. ' +
       'By default returns base64-encoded content for files ≤5MB. ' +
       'Set save_to_download_dir=true to write the file into the server-configured attachment download directory ' +
-      'and return only metadata (path, size, mime) — preferred for large files and for handing off to another MCP (e.g. Paperless).',
+      'and return only metadata (path, size, mime) — preferred for large files and for handing off to another MCP by path.',
     {
       account: z.string().describe('Account name from list_accounts'),
       id: z.string().describe('Email ID (UID) from list_emails or get_email'),

--- a/src/tools/attachments.tool.ts
+++ b/src/tools/attachments.tool.ts
@@ -6,20 +6,97 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import type ImapService from '../services/imap.service.js';
+import type { AppConfig } from '../types/index.js';
 
-export default function registerAttachmentTools(server: McpServer, imapService: ImapService): void {
+export default function registerAttachmentTools(
+  server: McpServer,
+  imapService: ImapService,
+  config: AppConfig,
+): void {
   server.tool(
     'download_attachment',
-    'Download an email attachment by filename. First use get_email to see available attachments and their filenames. Returns base64-encoded content for files ≤5MB.',
+    'Download an email attachment by filename. First use get_email to see available attachments and their filenames. ' +
+      'By default returns base64-encoded content for files ≤5MB. ' +
+      'Set save_to_download_dir=true to write the file into the server-configured attachment download directory ' +
+      'and return only metadata (path, size, mime) — preferred for large files and for handing off to another MCP (e.g. Paperless).',
     {
       account: z.string().describe('Account name from list_accounts'),
       id: z.string().describe('Email ID (UID) from list_emails or get_email'),
       mailbox: z.string().default('INBOX').describe('Mailbox containing the email'),
       filename: z.string().describe('Exact attachment filename (from get_email metadata)'),
+      save_to_download_dir: z
+        .boolean()
+        .default(false)
+        .describe(
+          'When true, save into MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR (or settings.attachment_download.dir) and omit base64. Requires the download dir to be configured.',
+        ),
+      save_as: z
+        .string()
+        .optional()
+        .describe(
+          'Optional basename only for the downloaded file (no paths). Defaults to a sanitized attachment filename. Ignored unless save_to_download_dir=true.',
+        ),
     },
     { readOnlyHint: true, destructiveHint: false },
-    async ({ account, id, mailbox, filename }) => {
+    async ({
+      account,
+      id,
+      mailbox,
+      filename,
+      save_to_download_dir: saveToDownloadDir,
+      save_as: saveAs,
+    }) => {
       try {
+        if (saveToDownloadDir) {
+          const downloadDir = config.settings.attachmentDownload.dir;
+          if (!downloadDir) {
+            return {
+              isError: true,
+              content: [
+                {
+                  type: 'text' as const,
+                  text:
+                    'Attachment download directory is not configured. Set MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR ' +
+                    '(or EMAIL_ATTACHMENT_DOWNLOAD_DIR) or [settings.attachment_download] dir in config.toml ' +
+                    'before using save_to_download_dir=true.',
+                },
+              ],
+            };
+          }
+
+          const result = await imapService.downloadAttachmentToDownloadDir(
+            account,
+            id,
+            mailbox,
+            filename,
+            {
+              downloadDir,
+              allowedExtensions: config.settings.attachmentDownload.allowedExtensions,
+              maxBytes: config.settings.attachmentDownload.maxBytes,
+              saveAs,
+            },
+          );
+
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify(
+                  {
+                    filename: result.filename,
+                    mimeType: result.mimeType,
+                    size: result.size,
+                    sizeHuman: `${Math.round(result.size / 1024)}KB`,
+                    savedTo: result.savedTo,
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        }
+
         const result = await imapService.downloadAttachment(account, id, mailbox, filename);
 
         return {

--- a/src/tools/register.test.ts
+++ b/src/tools/register.test.ts
@@ -41,6 +41,10 @@ function createConfig(readOnly: boolean): AppConfig {
     settings: {
       rateLimit: 10,
       readOnly,
+      attachmentDownload: {
+        allowedExtensions: ['pdf'],
+        maxBytes: 25 * 1024 * 1024,
+      },
       watcher: { enabled: false, folders: ['INBOX'], idleTimeout: 1740 },
       hooks: {
         onNewEmail: 'notify',

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -57,7 +57,7 @@ export default function registerAllTools(
   registerAccountsTools(server, connections);
   registerMailboxesTools(server, imapService);
   registerEmailsTools(server, imapService);
-  registerAttachmentTools(server, imapService);
+  registerAttachmentTools(server, imapService, config);
   registerContactsTools(server, imapService);
   registerThreadTools(server, imapService);
   registerTemplateReadTools(server, templateService);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,12 +137,22 @@ export interface HooksConfig {
   calendarConfirm?: boolean;
 }
 
+export interface AttachmentDownloadConfig {
+  /** Absolute directory for attachment downloads. Unset disables save_to_download_dir. */
+  dir?: string;
+  /** Allowed file extensions (lowercase, no leading dot). */
+  allowedExtensions: string[];
+  /** Max attachment size for download-dir writes. */
+  maxBytes: number;
+}
+
 export interface AppConfig {
   settings: {
     rateLimit: number;
     readOnly: boolean;
     watcher: WatcherConfig;
     hooks: HooksConfig;
+    attachmentDownload: AttachmentDownloadConfig;
   };
   accounts: AccountConfig[];
 }


### PR DESCRIPTION
- Extends `download_attachment` with `save_to_download_dir` / `save_as` so attachments can be written to a **server-configured** download directory and returned as metadata only (no base64), addressing #12 without freeform path writes.
- Safeguards: extension allowlist, basename-only `save_as` (path jail), atomic temp+rename writes that replace symlinks instead of writing through them.

## Still to do
- [x] Manual: set `MCP_EMAIL_ATTACHMENT_DOWNLOAD_DIR`, call with `save_to_download_dir=true`, confirm `savedTo` without base64
- [ ] Manual: missing dir config returns a clear error
- [ ] Manual: `save_as` with `../` or absolute path is rejected