### PR TITLE
feat(send): add attachment support to send_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@ Features:
 
 | Tool | Description |
 |------|-------------|
-| `send_email` | Send a new email (plain text or HTML, CC/BCC) |
+| `send_email` | Send a new email (plain text or HTML, CC/BCC, attachments) |
 | `reply_email` | Reply with proper threading (In-Reply-To, References) |
 | `forward_email` | Forward with original content quoted |
 | `save_draft` | Save an email draft to the Drafts folder |

--- a/src/safety/validation.test.ts
+++ b/src/safety/validation.test.ts
@@ -1,7 +1,11 @@
+import { mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   sanitizeMailboxName,
   sanitizeSearchQuery,
   sanitizeTemplateVariable,
+  validateAttachmentPath,
   validateInputLength,
   validateLabelName,
   validateWebhookUrl,
@@ -171,5 +175,51 @@ describe('validateInputLength', () => {
 
   it('allows under max length', () => {
     expect(() => validateInputLength('ab', 5, 'name')).not.toThrow();
+  });
+});
+
+describe('validateAttachmentPath', () => {
+  let dir: string;
+
+  beforeAll(async () => {
+    // realpath: on macOS the temp dir sits under /var, itself a symlink to
+    // /private/var, and validateAttachmentPath returns resolved paths.
+    dir = await realpath(await mkdtemp(join(tmpdir(), 'email-mcp-attach-')));
+  });
+
+  it('returns the resolved path and size for a readable file', async () => {
+    const file = join(dir, 'note.txt');
+    await writeFile(file, 'hello');
+    await expect(validateAttachmentPath(file, 1024)).resolves.toEqual({ path: file, size: 5 });
+  });
+
+  it('rejects a path containing a null byte', async () => {
+    await expect(validateAttachmentPath('/tmp/a\0b', 1024)).rejects.toThrow('null bytes');
+  });
+
+  it('rejects an empty path', async () => {
+    await expect(validateAttachmentPath('   ', 1024)).rejects.toThrow('must not be empty');
+  });
+
+  it('rejects a file that does not exist', async () => {
+    await expect(validateAttachmentPath(join(dir, 'missing.txt'), 1024)).rejects.toThrow();
+  });
+
+  it('rejects a directory', async () => {
+    await expect(validateAttachmentPath(dir, 1024)).rejects.toThrow('not a regular file');
+  });
+
+  it('rejects a file larger than the limit', async () => {
+    const big = join(dir, 'big.bin');
+    await writeFile(big, Buffer.alloc(2048));
+    await expect(validateAttachmentPath(big, 1024)).rejects.toThrow('exceeding');
+  });
+
+  it('resolves symlinks to their target', async () => {
+    const target = join(dir, 'target.txt');
+    const link = join(dir, 'link.txt');
+    await writeFile(target, 'data');
+    await symlink(target, link);
+    await expect(validateAttachmentPath(link, 1024)).resolves.toMatchObject({ path: target });
   });
 });

--- a/src/safety/validation.ts
+++ b/src/safety/validation.ts
@@ -1,5 +1,8 @@
 /** Input validation and sanitization utilities. */
 
+import { realpath, stat } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+
 /**
  * Validate and sanitize an IMAP mailbox name.
  * Rejects names containing IMAP wildcard characters (`*`, `%`) or empty strings.
@@ -118,4 +121,44 @@ export function validateInputLength(input: string, maxLength: number, fieldName:
   if (input.length > maxLength) {
     throw new Error(`${fieldName} exceeds maximum length of ${maxLength} characters`);
   }
+}
+
+/**
+ * Validate an attachment file path.
+ *
+ * Rejects paths containing null bytes or control characters, resolves the path
+ * to an absolute one, and ensures the target exists, is a regular file, and
+ * does not exceed the size limit. Symlinks are resolved before validation so a
+ * link cannot be used to reach an unintended target.
+ *
+ * @param filePath - The attachment path to validate.
+ * @param maxBytes - Maximum allowed file size in bytes.
+ * @returns The resolved absolute path and its size in bytes.
+ */
+export async function validateAttachmentPath(
+  filePath: string,
+  maxBytes: number,
+): Promise<{ path: string; size: number }> {
+  if (filePath.includes('\0')) {
+    throw new Error('Attachment path must not contain null bytes');
+  }
+
+  const trimmed = filePath.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Attachment path must not be empty');
+  }
+
+  const resolved = await realpath(resolve(trimmed));
+
+  const stats = await stat(resolved);
+  if (!stats.isFile()) {
+    throw new Error(`Attachment is not a regular file: ${filePath}`);
+  }
+  if (stats.size > maxBytes) {
+    throw new Error(
+      `Attachment ${basename(resolved)} is ${stats.size} bytes, exceeding the ${maxBytes} byte limit`,
+    );
+  }
+
+  return { path: resolved, size: stats.size };
 }

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -6,7 +6,7 @@
 
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
-import type { SendResult } from '../types/index.js';
+import type { Attachment, SendResult } from '../types/index.js';
 import type ImapService from './imap.service.js';
 
 export default class SmtpService {
@@ -29,6 +29,7 @@ export default class SmtpService {
       cc?: string[];
       bcc?: string[];
       html?: boolean;
+      attachments?: Attachment[];
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
@@ -43,6 +44,7 @@ export default class SmtpService {
       bcc: options.bcc?.join(', '),
       subject: options.subject,
       ...(options.html ? { html: options.body } : { text: options.body }),
+      ...(options.attachments?.length ? { attachments: options.attachments } : {}),
     });
 
     return {

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -5,9 +5,42 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import audit from '../safety/audit.js';
-import { validateInputLength } from '../safety/validation.js';
+import { validateAttachmentPath, validateInputLength } from '../safety/validation.js';
 
 import type SmtpService from '../services/smtp.service.js';
+
+/** Maximum size of a single attachment, in bytes. */
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/** Maximum combined size of all attachments on one message, in bytes. */
+const MAX_ATTACHMENTS_TOTAL_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Validate every attachment path and return nodemailer-ready descriptors.
+ * @param attachments - Raw attachment inputs from the tool call.
+ * @returns Resolved attachments, or undefined when none were supplied.
+ */
+async function resolveAttachments(
+  attachments?: { path: string; filename?: string; contentType?: string }[],
+): Promise<{ path: string; filename?: string; contentType?: string }[] | undefined> {
+  if (!attachments?.length) return undefined;
+
+  const resolved = await Promise.all(
+    attachments.map(async (a) => {
+      const { path, size } = await validateAttachmentPath(a.path, MAX_ATTACHMENT_BYTES);
+      return { ...a, path, size };
+    }),
+  );
+
+  const total = resolved.reduce((sum, a) => sum + a.size, 0);
+  if (total > MAX_ATTACHMENTS_TOTAL_BYTES) {
+    throw new Error(
+      `Combined attachment size is ${total} bytes, exceeding the ${MAX_ATTACHMENTS_TOTAL_BYTES} byte limit`,
+    );
+  }
+
+  return resolved.map(({ size: _size, ...rest }) => rest);
+}
 
 export default function registerSendTools(server: McpServer, smtpService: SmtpService): void {
   // ---------------------------------------------------------------------------
@@ -24,13 +57,30 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       cc: z.array(z.string().email()).optional().describe('CC recipients'),
       bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
       html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
+      attachments: z
+        .array(
+          z.object({
+            path: z.string().describe('Path to the file on the machine running this server'),
+            filename: z
+              .string()
+              .optional()
+              .describe('Name shown to the recipient (default: basename of path)'),
+            contentType: z
+              .string()
+              .optional()
+              .describe('MIME type (inferred from the filename when omitted)'),
+          }),
+        )
+        .optional()
+        .describe('Files to attach. Max 25MB per file and 25MB combined.'),
     },
     { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     async (params) => {
       try {
         validateInputLength(params.subject, 998, 'Subject');
         validateInputLength(params.body, 5_000_000, 'Body');
-        const result = await smtpService.sendEmail(params.account, params);
+        const attachments = await resolveAttachments(params.attachments);
+        const result = await smtpService.sendEmail(params.account, { ...params, attachments });
         await audit.log(
           'send_email',
           params.account,
@@ -41,7 +91,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}\nMessage-ID: ${result.messageId}`,
+              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}${attachments?.length ? `\nAttachments: ${attachments.length}` : ''}\nMessage-ID: ${result.messageId}`,
             },
           ],
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -351,6 +351,25 @@ export interface LabelInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+/**
+ * A file to attach to an outgoing message.
+ *
+ * `path` is a filesystem path readable by the MCP server process; it is
+ * validated and resolved before the message is sent.
+ */
+export interface Attachment {
+  /** Absolute or relative path to the file on the server host. */
+  path: string;
+  /** Name shown to the recipient. Defaults to the file's basename. */
+  filename?: string;
+  /** Explicit MIME type. Nodemailer infers it from the filename when omitted. */
+  contentType?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Scheduling
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

`send_email` had no way to attach files, ruling out common use cases such as sending a quote request with a spec sheet. The SMTP layer already runs on nodemailer, which supports attachments natively, so this adds the plumbing plus validation.

Adds an optional `attachments` parameter accepting a path, an optional display filename and an optional content type:

```json
{
  "account": "work",
  "to": ["supplier@example.com"],
  "subject": "Request for quotation",
  "body": "Please find the specification attached.",
  "attachments": [
    { "path": "/home/user/docs/spec.pdf" },
    { "path": "/home/user/docs/plan.pdf", "filename": "Floor plan.pdf" }
  ]
}
```

A new `validateAttachmentPath()` helper follows the conventions of the existing `safety/validation` module: it rejects null bytes and empty paths, resolves symlinks before validating so a link cannot reach an unintended target, confirms the target is a regular file, and enforces a 25MB per-file and combined limit. All filesystem calls use `node:fs/promises` to satisfy `n/no-sync`.

Scope is limited to `send_email`; `reply_email` and `forward_email` share the same code path and are straightforward follow-ups. Worth noting separately: `forward_email` currently drops the original attachments, which is arguably a distinct bug rather than a missing feature.

### Relation to #65

#65 covers the opposite direction — writing *received* attachments to a configured download directory instead of returning base64. The two changes are complementary and touch different tools, so there is no overlap in the diff.

There is a design question worth settling across both, though. #65 introduces a server-configured directory that bounds where attachments may be written. The symmetric constraint on send would be an allowlist bounding where attachments may be *read* from. I have not implemented that here, since it depends on a config shape #65 is still defining and I did not want to pre-empt it. Happy to add it in this PR or a follow-up, aligned with whatever key lands first.

### Verification

Also verified end to end against nodemailer's `streamTransport`: the generated message is `multipart/mixed`, with the attachment base64-encoded and the `Content-Disposition` header set correctly.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor (no functional changes)

## Checklist

- [x] My code follows the project's code style (Biome formatter + ESLint linter)
- [x] I have run `pnpm check` and it passes
- [x] I have run `pnpm typecheck` and it passes
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] I have updated documentation (if applicable)
- [x] My changes generate no new warnings