### PR TITLE
feat: expose sender authentication signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,7 @@ Features:
 | `list_mailboxes` | List folders with unread counts and special-use flags |
 | `list_emails` | Paginated email listing with date, sender, subject, and flag filters |
 | `get_email` | Read full email content with attachment metadata |
+| `get_email_security` | Read sender-authentication signals (SPF/DKIM/DMARC and related domains) without exposing raw headers or body |
 | `get_emails` | Fetch full content of multiple emails in a single call (max 20) |
 | `get_email_status` | Get read/flag/label state of an email without fetching the body |
 | `search_emails` | Search by keyword across subject, sender, and body |

--- a/src/__integration__/email-read.integration.test.ts
+++ b/src/__integration__/email-read.integration.test.ts
@@ -19,6 +19,18 @@ describe('Email Read Operations', () => {
     await seedEmails(5);
     await seedEmail({ from: 'alice@localhost', subject: 'From Alice' });
     await seedEmail({ from: 'bob@localhost', subject: 'Flagged email' });
+    await seedEmail({
+      from: 'authsender@localhost',
+      subject: 'Authenticated sender',
+      text: 'Authentication test message',
+      headers: {
+        'Authentication-Results':
+          'mx.example; spf=pass smtp.mailfrom=mailer.example; dkim=pass header.d=mailer.example header.s=very-long-selector-for-header-folding; dmarc=pass header.from=mailer.example',
+        'DKIM-Signature': 'v=1; a=rsa-sha256; d=mailer.example; s=test; b=placeholder',
+        'Reply-To': 'Support <support@reply.example>',
+        'List-Unsubscribe': '<mailto:unsubscribe@mailer.example>',
+      },
+    });
     await seedThread(3, { subject: 'Discussion Topic' });
     await waitForDelivery();
   });
@@ -94,6 +106,31 @@ describe('Email Read Operations', () => {
       expect(email.subject).toBeTruthy();
       expect(email.from).toBeDefined();
       expect(email.messageId).toBeTruthy();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // get_email_security
+  // ---------------------------------------------------------------------------
+
+  describe('getEmailSecurity', () => {
+    it('should expose derived sender-authentication signals without reading the body', async () => {
+      const all = await services.imapService.listEmails(TEST_ACCOUNT_NAME, { pageSize: 50 });
+      const target = all.items.find((email) => email.subject === 'Authenticated sender');
+      expect(target).toBeDefined();
+
+      const security = await services.imapService.getEmailSecurity(
+        TEST_ACCOUNT_NAME,
+        target?.id ?? '',
+      );
+
+      expect(security.authenticationResultsPresent).toBe(true);
+      expect(security.spf).toContain('pass');
+      expect(security.dkim).toContain('pass');
+      expect(security.dmarc).toContain('pass');
+      expect(security.dkimDomains).toContain('mailer.example');
+      expect(security.replyToDomain).toBe('reply.example');
+      expect(security.listUnsubscribe).toBe(true);
     });
   });
 

--- a/src/__integration__/helpers/seed.ts
+++ b/src/__integration__/helpers/seed.ts
@@ -11,6 +11,7 @@ interface SeedEmailOptions {
   bcc?: string[];
   inReplyTo?: string;
   references?: string[];
+  headers?: Record<string, string>;
   attachments?: {
     filename: string;
     content: string | Buffer;
@@ -44,6 +45,7 @@ export async function seedEmail(options: SeedEmailOptions = {}) {
       bcc: options.bcc?.join(', '),
       inReplyTo: options.inReplyTo,
       references: options.references?.join(' '),
+      headers: options.headers,
       attachments: options.attachments,
     });
     return info.messageId;

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -15,6 +15,7 @@ import type {
   Email,
   EmailAddress,
   EmailMeta,
+  EmailSecurityInfo,
   EmailStats,
   LabelInfo,
   Mailbox,
@@ -39,6 +40,48 @@ function parseAddress(addr: { name?: string; address?: string } | undefined): Em
 function parseAddresses(addrs: { name?: string; address?: string }[] | undefined): EmailAddress[] {
   if (!addrs) return [];
   return addrs.map(parseAddress);
+}
+
+function parseHeaderBuffer(buffer: Buffer): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const unfolded = buffer.toString('utf-8').replace(/\r?\n[ \t]+/g, ' ');
+
+  for (const line of unfolded.split(/\r?\n/)) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx <= 0) continue;
+
+    const key = line.slice(0, colonIdx).trim().toLowerCase();
+    const value = line.slice(colonIdx + 1).trim();
+    if (!key || !value) continue;
+
+    headers[key] = headers[key] ? `${headers[key]}\n${value}` : value;
+  }
+
+  return headers;
+}
+
+function addressDomain(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const angle = /<\s*([^<>\s]+@[^<>\s]+)\s*>/.exec(value);
+  const plain = /([A-Z0-9._%+\-]+@([A-Z0-9.\-]+))/i.exec(angle?.[1] ?? value);
+  return plain?.[2]?.replace(/[>;,]+$/, '').toLowerCase();
+}
+
+function authStatuses(value: string | undefined, method: 'spf' | 'dkim' | 'dmarc'): string[] {
+  if (!value) return [];
+  const pattern = new RegExp(`(?:^|[;\\s])${method}\\s*=\\s*([a-z][a-z0-9_-]*)`, 'gi');
+  return [...new Set([...value.matchAll(pattern)].map((match) => match[1].toLowerCase()))];
+}
+
+function dkimSigningDomains(authenticationResults: string, dkimSignature: string): string[] {
+  const domains = new Set<string>();
+  for (const match of authenticationResults.matchAll(/\bheader\.d\s*=\s*([^;\s]+)/gi)) {
+    domains.add(match[1].replace(/[<>;,]+$/g, '').toLowerCase());
+  }
+  for (const match of dkimSignature.matchAll(/(?:^|;)\s*d\s*=\s*([^;\s]+)/gi)) {
+    domains.add(match[1].replace(/[<>;,]+$/g, '').toLowerCase());
+  }
+  return [...domains];
 }
 
 function hasAttachments(bodyStructure: unknown): boolean {
@@ -426,6 +469,60 @@ export default class ImapService {
       }
 
       return await messageToEmail(msg as unknown as Record<string, unknown>, client, uid);
+    } finally {
+      lock.release();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Get sender-authentication signals (lightweight — headers only, no body fetch)
+  // -------------------------------------------------------------------------
+
+  async getEmailSecurity(
+    accountName: string,
+    emailId: string,
+    mailbox = 'INBOX',
+  ): Promise<EmailSecurityInfo> {
+    const client = await this.connections.getImapClient(accountName);
+    const uid = parseInt(emailId, 10);
+    const safeMailbox = sanitizeMailboxName(mailbox);
+
+    const lock = await client.getMailboxLock(safeMailbox);
+    try {
+      const msg = await client.fetchOne(
+        String(uid),
+        { uid: true, envelope: true, headers: true },
+        { uid: true },
+      );
+
+      if (!msg) {
+        throw new Error(`Email ${emailId} not found in ${mailbox}`);
+      }
+
+      const headers =
+        msg.headers && Buffer.isBuffer(msg.headers) ? parseHeaderBuffer(msg.headers) : {};
+      const envelope = (msg.envelope ?? {}) as Record<string, unknown>;
+      const from = parseAddress((envelope.from as Record<string, string>[])?.[0]);
+      const authenticationResults = headers['authentication-results'] ?? '';
+      const receivedSpf = headers['received-spf'] ?? '';
+      const spf = new Set(authStatuses(authenticationResults, 'spf'));
+      const receivedSpfStatus = /^\s*([a-z][a-z0-9_-]*)/i.exec(receivedSpf)?.[1]?.toLowerCase();
+      if (receivedSpfStatus) spf.add(receivedSpfStatus);
+
+      return {
+        fromDomain: addressDomain(from.address),
+        returnPathDomain: addressDomain(headers['return-path']),
+        replyToDomain: addressDomain(headers['reply-to']),
+        spf: [...spf],
+        dkim: authStatuses(authenticationResults, 'dkim'),
+        dmarc: authStatuses(authenticationResults, 'dmarc'),
+        dkimDomains: dkimSigningDomains(
+          authenticationResults,
+          headers['dkim-signature'] ?? '',
+        ),
+        authenticationResultsPresent: Boolean(authenticationResults),
+        listUnsubscribe: Boolean(headers['list-unsubscribe']),
+      };
     } finally {
       lock.release();
     }

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -1,5 +1,5 @@
 /**
- * MCP tools: list_emails, get_email, get_emails, get_email_status, search_emails
+ * MCP tools: list_emails, get_email, get_email_security, get_emails, get_email_status, search_emails
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -176,6 +176,56 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
             {
               type: 'text' as const,
               text: `Failed to list emails: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // get_email_security
+  // ---------------------------------------------------------------------------
+  server.tool(
+    'get_email_security',
+    'Get read-only sender-authentication signals for an email without returning the raw header block or body. ' +
+      'Reports SPF, DKIM, DMARC, sender-related domains, DKIM signing domains, and List-Unsubscribe presence. ' +
+      'Does not mark the email as seen. Missing authentication results are reported as unavailable, not as failure.',
+    {
+      account: z.string().describe('Account name from list_accounts'),
+      emailId: z.string().describe('Email ID from list_emails or search_emails'),
+      mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
+    },
+    { readOnlyHint: true, destructiveHint: false },
+    async ({ account, emailId, mailbox }) => {
+      try {
+        const security = await imapService.getEmailSecurity(account, emailId, mailbox);
+        const renderStatuses = (values: string[]) =>
+          values.length > 0 ? values.join(', ') : 'not reported';
+
+        const parts = [
+          '🔐 Email security signals',
+          `From domain:        ${security.fromDomain ?? 'not available'}`,
+          `Return-Path domain: ${security.returnPathDomain ?? 'not available'}`,
+          `Reply-To domain:    ${security.replyToDomain ?? 'not available'}`,
+          `SPF:                ${renderStatuses(security.spf)}`,
+          `DKIM:               ${renderStatuses(security.dkim)}`,
+          `DMARC:              ${renderStatuses(security.dmarc)}`,
+          `DKIM domains:       ${security.dkimDomains.length > 0 ? security.dkimDomains.join(', ') : 'not reported'}`,
+          `Authentication-Results: ${security.authenticationResultsPresent ? 'present' : 'not present'}`,
+          `List-Unsubscribe:       ${security.listUnsubscribe ? 'present' : 'not present'}`,
+          '',
+          'Note: these are signals supplied by the receiving mail system; absence alone is not an authentication failure.',
+        ];
+
+        return { content: [{ type: 'text' as const, text: parts.join('\n') }] };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: `Failed to get email security signals: ${err instanceof Error ? err.message : String(err)}`,
             },
           ],
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,6 +195,18 @@ export interface Email extends EmailMeta {
   headers: Record<string, string>;
 }
 
+export interface EmailSecurityInfo {
+  fromDomain?: string;
+  returnPathDomain?: string;
+  replyToDomain?: string;
+  spf: string[];
+  dkim: string[];
+  dmarc: string[];
+  dkimDomains: string[];
+  authenticationResultsPresent: boolean;
+  listUnsubscribe: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Results
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a focused read-only `get_email_security` tool for sender-authentication signals without exposing the raw header block or message body.

The tool fetches headers only and derives:
- SPF results
- DKIM results
- DMARC results
- From, Return-Path, and Reply-To domains
- DKIM signing domains (`d=` / `header.d=`)
- whether `Authentication-Results` is present
- whether `List-Unsubscribe` is present

## Safety / compatibility

- read-only MCP tool (`readOnlyHint: true`)
- no raw headers or body returned
- no credentials or secret values exposed
- no provider-specific trust verdict; signals are reported as received
- missing authentication results are treated as unavailable, not as authentication failure
- existing email tools and outputs remain unchanged
- header-only IMAP fetch avoids the full-body cost of `get_email`

## Tests

Integration coverage seeds a message with Authentication-Results, DKIM-Signature, Reply-To and List-Unsubscribe, then verifies the derived security result including folded-header-safe parsing.

Fixes #69