### PR TITLE
fix(schemas): remove lookahead regex that breaks tool calling on llama.cpp models (SDK v2 branch)

### DIFF
--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -26,13 +26,19 @@ export default function registerDraftTools(
       inputSchema: z.object({
         account: z.string().describe('Account name from list_accounts'),
         to: z
-          .array(z.string().email())
+          .array(z.email({ pattern: z.regexes.html5Email }))
           .default([])
           .describe('Recipient email addresses (can be empty for drafts)'),
         subject: z.string().describe('Email subject'),
         body: z.string().describe('Email body content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
-        bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
+        bcc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('BCC recipients'),
         html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
         in_reply_to: z.string().optional().describe('Message-ID for threading (from get_email)'),
       }),

--- a/src/tools/schema-grammar-safety.test.ts
+++ b/src/tools/schema-grammar-safety.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Guards a property of the whole tool surface, not of any one tool:
+ *
+ *   No tool input schema may emit a regex containing a lookaround assertion.
+ *
+ * llama.cpp compiles the entire `tools` array into a single GBNF grammar for
+ * constrained decoding, and GBNF has no lookahead/lookbehind. One offending
+ * `pattern` anywhere aborts grammar compilation, so every tool in the request
+ * fails — including tools belonging to other servers. OpenAI's tool-schema
+ * validator rejects the same construct ("regex lookaround is not supported").
+ *
+ * This is why the check walks every registered tool rather than asserting on
+ * the handful of call sites that happened to be wrong: the next `.email()`,
+ * `.url()`, or hand-written `.regex()` must fail here too.
+ *
+ * See upstream issue #58.
+ */
+
+import { z } from 'zod';
+import type { AppConfig } from '../types/index.js';
+import registerAllTools from './register.js';
+
+/** Matches lookahead `(?=` `(?!` and lookbehind `(?<=` `(?<!`, ignoring `(?:`. */
+const LOOKAROUND = /\((?:\?=|\?!|\?<=|\?<!)/;
+
+interface CapturedTool {
+  name: string;
+  shape: z.ZodRawShape | z.ZodTypeAny;
+}
+
+/** Stands in for any service: every property is a no-op function. */
+function serviceStub(): unknown {
+  return new Proxy(
+    {},
+    {
+      get: () => () => undefined,
+    },
+  );
+}
+
+function createConfig(): AppConfig {
+  return {
+    settings: {
+      rateLimit: 10,
+      readOnly: false,
+      cache: {
+        enabled: false,
+        mailboxes: ['INBOX'],
+        windowDays: 30,
+        bodyMessages: 200,
+        maxSizeMb: 100,
+        syncInterval: 300,
+      },
+      watcher: { enabled: false, folders: ['INBOX'], idleTimeout: 1740 },
+      hooks: {
+        onNewEmail: 'notify',
+        preset: 'priority-focus',
+        autoLabel: false,
+        autoFlag: false,
+        batchDelay: 5,
+        rules: [],
+        alerts: {
+          desktop: false,
+          sound: false,
+          urgencyThreshold: 'high',
+          webhookUrl: '',
+          webhookEvents: ['urgent', 'high'],
+        },
+      },
+    },
+    accounts: [],
+  };
+}
+
+function captureRegisteredTools(): CapturedTool[] {
+  const captured: CapturedTool[] = [];
+
+  const recordTool = (name: string, ...rest: unknown[]): void => {
+    // server.tool(name, description?, shape?, annotations?, handler)
+    const shape = rest.find(
+      (arg) => typeof arg === 'object' && arg !== null && !Array.isArray(arg),
+    ) as z.ZodRawShape | undefined;
+    if (shape) captured.push({ name, shape });
+  };
+
+  const fakeServer = {
+    tool: recordTool,
+    registerTool: (name: string, cfg: { inputSchema?: z.ZodRawShape | z.ZodTypeAny }) => {
+      if (cfg?.inputSchema) captured.push({ name, shape: cfg.inputSchema });
+    },
+    prompt: () => undefined,
+    resource: () => undefined,
+    server: serviceStub(),
+  };
+
+  const stub = serviceStub() as never;
+  registerAllTools(
+    fakeServer as never,
+    stub,
+    stub,
+    stub,
+    createConfig(),
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+  );
+
+  return captured;
+}
+
+/**
+ * A tool's input schema arrives either as a raw shape (`server.tool`, SDK v1)
+ * or as a `ZodObject` (`server.registerTool`, SDK v2). Normalize both, and
+ * return null only when the schema genuinely cannot be serialized — which the
+ * companion test treats as a failure, not as something to skip. Swallowing it
+ * silently is how this guard would pass while checking nothing.
+ */
+function toJson(shape: z.ZodRawShape | z.ZodTypeAny): string | null {
+  const schema = shape instanceof z.ZodType ? shape : z.object(shape);
+  try {
+    return JSON.stringify(z.toJSONSchema(schema));
+  } catch {
+    return null;
+  }
+}
+
+describe('tool schemas are GBNF-compilable', () => {
+  const tools = captureRegisteredTools();
+
+  it('registers a meaningful number of tools (guards against a silent no-op)', () => {
+    expect(tools.length).toBeGreaterThan(20);
+  });
+
+  it('can serialize every captured tool schema (guards against a vacuous pass)', () => {
+    const unserializable = tools.filter(({ shape }) => toJson(shape) === null).map((t) => t.name);
+    expect(unserializable).toEqual([]);
+  });
+
+  it('emits no lookaround assertions in any tool input schema', () => {
+    const offenders: string[] = [];
+
+    for (const { name, shape } of tools) {
+      const json = toJson(shape);
+      if (json !== null && LOOKAROUND.test(json)) {
+        const pattern = /"pattern":"((?:[^"\\]|\\.)*)"/.exec(json)?.[1] ?? '(unknown)';
+        offenders.push(`${name}: ${pattern}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -20,11 +20,20 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       description: 'Send a new email. Supports plain text or HTML body, CC, and BCC.',
       inputSchema: z.object({
         account: z.string().describe('Account name from list_accounts'),
-        to: z.array(z.string().email()).min(1).describe('Recipient email addresses'),
+        to: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .min(1)
+          .describe('Recipient email addresses'),
         subject: z.string().describe('Email subject'),
         body: z.string().describe('Email body content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
-        bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
+        bcc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('BCC recipients'),
         html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
       }),
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
@@ -141,9 +150,15 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
         account: z.string().describe('Account name from list_accounts'),
         emailId: z.string().describe('Email ID to forward (from list_emails or get_email)'),
         mailbox: z.string().default('INBOX').describe('Mailbox where the original email is'),
-        to: z.array(z.string().email()).min(1).describe('Forward to these recipients'),
+        to: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .min(1)
+          .describe('Forward to these recipients'),
         body: z.string().optional().describe('Additional message above the forwarded content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
       }),
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     },


### PR DESCRIPTION
Same fix as #72, rebased onto `modernize/sdk-v2-2026-07-28` so it isn't lost when that branch lands. Close whichever of the two you don't want.

Ref #58.

## Why it matters

Today this server cannot be used with any model served through llama.cpp — LM Studio, Ollama, llama-server. Every tool call fails before the model generates a token:

```
invalid_request_error: Failed to initialize samplers: failed to parse grammar
```

llama.cpp compiles the whole `tools` array into one GBNF grammar, so three bad tools take down all 41 tools on this branch **and every tool from every other MCP server in the same request**.

## Cause

`send_email`, `save_draft` and `forward_email` still use `z.string().email()` here. zod 4 emits a Gmail-style pattern with two negative lookaheads:

```
^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
```

GBNF has no lookaround, so the grammar fails to compile. OpenAI's tool-schema validator rejects the same construct (`regex lookaround is not supported`), so this is not llama.cpp-specific.

## Change

Eight call sites move to `z.email({ pattern: z.regexes.html5Email })` — the pattern browsers use for `input[type=email]`, which has no lookarounds.

The emitted JSON Schema keeps `"type": "string"` and `"format": "email"`; only the `pattern` string changes. Nothing the model sees is removed. For an MCP input schema the pattern is advisory to the model anyway, and the SMTP layer still rejects malformed addresses, so validation strength is unchanged in practice.

## Test

`src/tools/schema-grammar-safety.test.ts` walks the **entire registered tool surface** and fails on any input schema whose `pattern` contains lookaround, rather than asserting on these eight lines. The next `.email()`, `.url()` or hand-written `.regex()` that reintroduces the problem fails here instead of in a user's client.

One detail worth flagging for this branch: `registerTool` hands the guard a `ZodObject`, where SDK v1's `server.tool` handed it a raw shape. The first draft of the guard only understood raw shapes, so `z.toJSONSchema` threw, the failure was skipped, and the test passed while checking nothing. It now normalizes both forms and has a companion assertion that fails if any captured schema cannot be serialized, so it can't go quiet like that again.

Verified to fail on the pre-fix code, naming `send_email`, `save_draft` and `forward_email`.

## Checks

- `pnpm check` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 257 passing
