### PR TITLE
fix(schemas): remove lookahead regex that breaks tool calling on llama.cpp models (SDK v2)

### DIFF
--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -26,13 +26,19 @@ export default function registerDraftTools(
       inputSchema: z.object({
         account: z.string().describe('Account name from list_accounts'),
         to: z
-          .array(z.string().email())
+          .array(z.email({ pattern: z.regexes.html5Email }))
           .default([])
           .describe('Recipient email addresses (can be empty for drafts)'),
         subject: z.string().describe('Email subject'),
         body: z.string().describe('Email body content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
-        bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
+        bcc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('BCC recipients'),
         html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
         in_reply_to: z.string().optional().describe('Message-ID for threading (from get_email)'),
       }),

--- a/src/tools/schema-grammar-safety.test.ts
+++ b/src/tools/schema-grammar-safety.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Guards a property of the whole tool surface, not of any one tool:
+ *
+ *   No tool input schema may emit a regex containing a lookaround assertion.
+ *
+ * llama.cpp compiles the entire `tools` array into a single GBNF grammar for
+ * constrained decoding, and GBNF has no lookahead/lookbehind. One offending
+ * `pattern` anywhere aborts grammar compilation, so every tool in the request
+ * fails — including tools belonging to other servers. OpenAI's tool-schema
+ * validator rejects the same construct ("regex lookaround is not supported").
+ *
+ * This is why the check walks every registered tool rather than asserting on
+ * the handful of call sites that happened to be wrong: the next `.email()`,
+ * `.url()`, or hand-written `.regex()` must fail here too.
+ *
+ * See upstream issue #58.
+ */
+
+import { z } from 'zod';
+import type { AppConfig } from '../types/index.js';
+import registerAllTools from './register.js';
+
+/** Matches lookahead `(?=` `(?!` and lookbehind `(?<=` `(?<!`, ignoring `(?:`. */
+const LOOKAROUND = /\((?:\?=|\?!|\?<=|\?<!)/;
+
+interface CapturedTool {
+  name: string;
+  shape: z.ZodRawShape | z.ZodTypeAny;
+}
+
+/** Stands in for any service: every property is a no-op function. */
+function serviceStub(): unknown {
+  return new Proxy(
+    {},
+    {
+      get: () => () => undefined,
+    },
+  );
+}
+
+function createConfig(): AppConfig {
+  return {
+    settings: {
+      rateLimit: 10,
+      readOnly: false,
+      cache: {
+        enabled: false,
+        mailboxes: ['INBOX'],
+        windowDays: 30,
+        bodyMessages: 200,
+        maxSizeMb: 100,
+        syncInterval: 300,
+      },
+      watcher: { enabled: false, folders: ['INBOX'], idleTimeout: 1740 },
+      hooks: {
+        onNewEmail: 'notify',
+        preset: 'priority-focus',
+        autoLabel: false,
+        autoFlag: false,
+        batchDelay: 5,
+        rules: [],
+        alerts: {
+          desktop: false,
+          sound: false,
+          urgencyThreshold: 'high',
+          webhookUrl: '',
+          webhookEvents: ['urgent', 'high'],
+        },
+      },
+    },
+    accounts: [],
+  };
+}
+
+function captureRegisteredTools(): CapturedTool[] {
+  const captured: CapturedTool[] = [];
+
+  const recordTool = (name: string, ...rest: unknown[]): void => {
+    // server.tool(name, description?, shape?, annotations?, handler)
+    const shape = rest.find(
+      (arg) => typeof arg === 'object' && arg !== null && !Array.isArray(arg),
+    ) as z.ZodRawShape | undefined;
+    if (shape) captured.push({ name, shape });
+  };
+
+  const fakeServer = {
+    tool: recordTool,
+    registerTool: (name: string, cfg: { inputSchema?: z.ZodRawShape | z.ZodTypeAny }) => {
+      if (cfg?.inputSchema) captured.push({ name, shape: cfg.inputSchema });
+    },
+    prompt: () => undefined,
+    resource: () => undefined,
+    server: serviceStub(),
+  };
+
+  const stub = serviceStub() as never;
+  registerAllTools(
+    fakeServer as never,
+    stub,
+    stub,
+    stub,
+    createConfig(),
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+    stub,
+  );
+
+  return captured;
+}
+
+/**
+ * A tool's input schema arrives either as a raw shape (`server.tool`, SDK v1)
+ * or as a `ZodObject` (`server.registerTool`, SDK v2). Normalize both, and
+ * return null only when the schema genuinely cannot be serialized — which the
+ * companion test treats as a failure, not as something to skip. Swallowing it
+ * silently is how this guard would pass while checking nothing.
+ */
+function toJson(shape: z.ZodRawShape | z.ZodTypeAny): string | null {
+  const schema = shape instanceof z.ZodType ? shape : z.object(shape);
+  try {
+    return JSON.stringify(z.toJSONSchema(schema));
+  } catch {
+    return null;
+  }
+}
+
+describe('tool schemas are GBNF-compilable', () => {
+  const tools = captureRegisteredTools();
+
+  it('registers a meaningful number of tools (guards against a silent no-op)', () => {
+    expect(tools.length).toBeGreaterThan(20);
+  });
+
+  it('can serialize every captured tool schema (guards against a vacuous pass)', () => {
+    const unserializable = tools.filter(({ shape }) => toJson(shape) === null).map((t) => t.name);
+    expect(unserializable).toEqual([]);
+  });
+
+  it('emits no lookaround assertions in any tool input schema', () => {
+    const offenders: string[] = [];
+
+    for (const { name, shape } of tools) {
+      const json = toJson(shape);
+      if (json !== null && LOOKAROUND.test(json)) {
+        const pattern = /"pattern":"((?:[^"\\]|\\.)*)"/.exec(json)?.[1] ?? '(unknown)';
+        offenders.push(`${name}: ${pattern}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -20,11 +20,20 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       description: 'Send a new email. Supports plain text or HTML body, CC, and BCC.',
       inputSchema: z.object({
         account: z.string().describe('Account name from list_accounts'),
-        to: z.array(z.string().email()).min(1).describe('Recipient email addresses'),
+        to: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .min(1)
+          .describe('Recipient email addresses'),
         subject: z.string().describe('Email subject'),
         body: z.string().describe('Email body content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
-        bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
+        bcc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('BCC recipients'),
         html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
       }),
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
@@ -141,9 +150,15 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
         account: z.string().describe('Account name from list_accounts'),
         emailId: z.string().describe('Email ID to forward (from list_emails or get_email)'),
         mailbox: z.string().default('INBOX').describe('Mailbox where the original email is'),
-        to: z.array(z.string().email()).min(1).describe('Forward to these recipients'),
+        to: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .min(1)
+          .describe('Forward to these recipients'),
         body: z.string().optional().describe('Additional message above the forwarded content'),
-        cc: z.array(z.string().email()).optional().describe('CC recipients'),
+        cc: z
+          .array(z.email({ pattern: z.regexes.html5Email }))
+          .optional()
+          .describe('CC recipients'),
       }),
       annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     },


### PR DESCRIPTION
Ref #58. Same fix as #74, rebased onto `modernize/sdk-v2-2026-07-28` so it doesn't get lost when that branch lands.

Merge whichever base you ship first; the other closes on its own.

Three tool schemas emit a regex containing lookahead assertions. llama.cpp cannot compile a grammar from it, so **every tool call to this server fails on every llama.cpp-backed model** — LM Studio, Ollama, llama-server. The failure is total and happens before inference starts.

This replaces the offending validator at all eight call sites and adds a property test over the whole tool surface so it cannot come back.

---

## 1. Impact

Any user whose model is served by llama.cpp cannot use this server at all. That is most local-model setups.

The blast radius is larger than this server. llama.cpp compiles the entire `tools` array into a **single** GBNF grammar for constrained decoding. One uncompilable `pattern` anywhere aborts the whole compilation, so three bad tools here take down:

- all 49 tools this server registers, and
- **every tool from every other MCP server in the same request**

From the user's side that presents as "my whole agent broke when I added email-mcp", which is a hard failure to attribute to this package.

## 2. Reproduction

Any llama.cpp-backed endpoint, any model, any tool call:

```
invalid_request_error: Failed to initialize samplers: failed to parse grammar
```

Reported against `@codefuturist/email-mcp@0.2.3` with `zod@^4.3.6` on Node 24 / macOS, client chain OpenCode → Bifrost → LM Studio.

## 3. Root cause

`send_email`, `save_draft` and `forward_email` validate recipients with `z.string().email()`.

In zod 4 that emits a Gmail-style pattern carrying two negative lookaheads:

```
^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$
```

`(?!\.)` forbids a leading dot; `(?!.*\.\.)` forbids a doubled dot. GBNF — the grammar format llama.cpp uses for constrained decoding — has no lookahead or lookbehind, so it cannot represent either one and aborts.

This is not llama.cpp-specific. OpenAI's tool-schema validator rejects the same construct outright:

> `regex lookaround is not supported`

Same root cause, different server: SmartBear/smartbear-mcp#491.

## 4. Isolating it

Narrowed to a single JSON Schema property:

| schema | result |
| --- | --- |
| `{"type":"string"}` | works |
| `{"type":"string","format":"email"}` | works — `format` is advisory and ignored |
| `{"type":"string","pattern":"<lookahead regex>"}` | **fails** |

So it is the `pattern`, not `format`, and not the email concept.

Confirmed against a real 76-tool array by bisection: 76 → 38 → 19 → 10 → 5 → 2 → 1. Removing only `send_email`, `save_draft` and `forward_email` restores the request. 10 runs out of 10.

## 5. The change

Eight call sites, one substitution:

```diff
-  to: z.array(z.string().email()).min(1)
+  to: z.array(z.email({ pattern: z.regexes.html5Email })).min(1)
```

| file | fields |
| --- | --- |
| `src/tools/send.tool.ts` — `send_email` | `to`, `cc`, `bcc` |
| `src/tools/send.tool.ts` — `forward_email` | `to`, `cc` |
| `src/tools/drafts.tool.ts` — `save_draft` | `to`, `cc`, `bcc` |

## 6. Why `html5Email` specifically

`z.regexes.html5Email` is the pattern from the WHATWG HTML spec for `input[type=email]` — the one every browser already enforces on every email field on the web:

```
^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$
```

It contains only non-capturing groups (`(?:`), which GBNF handles. No lookarounds.

It ships with zod, so this adds no dependency and no hand-rolled regex to maintain.

## 7. Does this weaken validation?

The emitted JSON Schema is the same shape. Only the `pattern` string differs:

```jsonc
// before
{"type":"string","format":"email","pattern":"^(?!\\.)(?!.*\\.\\.)…"}
// after
{"type":"string","format":"email","pattern":"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@…"}
```

`type` and `format` are untouched, so nothing the model is told about the field is removed.

What the two patterns actually disagree on is narrow: the zod default additionally rejects a leading dot (`.a@b.com`) and a doubled dot (`a..b@c.com`). Both are already invalid per RFC 5322 unquoted, and both are rejected downstream:

- **For the model**, an MCP input schema's `pattern` is advisory. It shapes generation; it is not the enforcement boundary.
- **For delivery**, nodemailer and the receiving MTA parse and reject malformed addresses regardless of what passed here.

So in practice the enforcement is unchanged, and the change buys back the ability to run at all on a large share of clients. That trade is the whole point of the PR.

## 8. Alternatives considered

- **Drop the validator entirely** (`z.string()`). Compiles fine, but discards the `format: "email"` hint the model uses. Rejected — loses more than it needs to.
- **Post-process the emitted JSON Schema** to strip lookarounds before registration. Fixes every case automatically, but adds a schema-rewriting layer to the hot path and hides the problem from anyone reading the tool definitions. Rejected as too invasive for this bug.
- **Hand-write a lookaround-free email regex.** Same result as `html5Email` but becomes ours to maintain and get wrong. Rejected.
- **`z.email({ pattern: z.regexes.html5Email })`.** Chosen: no new dependency, no new regex, no new layer, and the constraint stays visible at the call site.

## 9. The test, and the trap it has to survive

`src/tools/schema-grammar-safety.test.ts` asserts a property of the **whole tool surface**, not of these eight lines:

> No tool input schema may emit a regex containing a lookaround assertion.

It registers every tool against a recording stub, serializes each input schema, and fails on any `(?=` `(?!` `(?<=` `(?<!`. So the next `.email()`, `.url()` or hand-written `.regex()` that reintroduces this fails here, in CI, instead of in a user's client.

A test like this fails in one specific way: it goes quiet. If schema capture or serialization breaks, it inspects nothing and reports green. Two guards against that:

- it asserts a **minimum tool count**, so a registration stub that silently records nothing fails, and
- it asserts **every captured schema actually serialized**, so a schema it could not read is a failure rather than something skipped.

That second guard is not hypothetical, and this branch is where it bites. Here `registerTool` hands the guard a `ZodObject` where `server.tool` hands it a raw shape. The first draft of the test only understood raw shapes, so serialization threw, the throw was swallowed, and the test passed while checking **nothing at all**. It was caught by running the guard against unpatched code and noticing it did not fail. The version in this PR handles both forms.

**Verified negative:** reverted the two source files, ran the guard, it fails and names all three offenders:

```
AssertionError: expected [ …(3) ] to deeply equal []
+   "send_email: ^(?!\\.)(?!.*\\.\\.)…"
+   "forward_email: ^(?!\\.)(?!.*\\.\\.)…"
+   "save_draft: ^(?!\\.)(?!.*\\.\\.)…"
```

## 10. Scope and risk

- **No behavioral change for anyone who is working today.** Addresses accepted before are accepted now; the two rejected edge forms are still rejected downstream.
- **No API change.** No tool signature, description, or return shape moves.
- **No new dependency.** `z.regexes` is part of zod 4.
- **The other `.url()` uses are unaffected.** `src/config/schema.ts` validates the config file, not tool input, so it never reaches a grammar — and `z.string().url()` emits `format: "uri"` with no `pattern` anyway.

## 11. Checks

Branched from `modernize/sdk-v2-2026-07-28` at 7fe8916.

- `pnpm check` — clean, 120 files
- `pnpm typecheck` — clean
- `pnpm test` — 257 passing

## 12. Note on `main`

#74 is the same fix against `main`, for whichever of the two you merge first.

