### PR TITLE
feat: support file attachments on send_email, reply_email, forward_email, and drafts

### DIFF
--- a/src/safety/validation.test.ts
+++ b/src/safety/validation.test.ts
@@ -2,6 +2,7 @@ import {
   sanitizeMailboxName,
   sanitizeSearchQuery,
   sanitizeTemplateVariable,
+  validateAttachments,
   validateInputLength,
   validateLabelName,
   validateWebhookUrl,
@@ -155,6 +156,72 @@ describe('validateLabelName', () => {
 
   it('trims whitespace and returns valid name', () => {
     expect(validateLabelName('  Important  ')).toBe('Important');
+  });
+});
+
+describe('validateAttachments', () => {
+  it('allows undefined and empty arrays', () => {
+    expect(() => validateAttachments(undefined)).not.toThrow();
+    expect(() => validateAttachments([])).not.toThrow();
+  });
+
+  it('allows a valid base64 attachment', () => {
+    expect(() =>
+      validateAttachments([
+        { filename: 'a.txt', content: Buffer.from('hello').toString('base64') },
+      ]),
+    ).not.toThrow();
+  });
+
+  it('allows a valid path-based attachment', () => {
+    expect(() => validateAttachments([{ filename: 'a.txt', path: '/tmp/a.txt' }])).not.toThrow();
+  });
+
+  it('throws when more than the max number of attachments are given', () => {
+    const attachments = Array.from({ length: 11 }, (_, i) => ({
+      filename: `f${i}.txt`,
+      content: 'aGVsbG8=',
+    }));
+    expect(() => validateAttachments(attachments)).toThrow('Too many attachments');
+  });
+
+  it('throws on empty filename', () => {
+    expect(() => validateAttachments([{ filename: '', content: 'aGVsbG8=' }])).toThrow(
+      'non-empty filename',
+    );
+  });
+
+  it('throws on filename with a path separator', () => {
+    expect(() => validateAttachments([{ filename: '../evil.txt', content: 'aGVsbG8=' }])).toThrow(
+      'path separators',
+    );
+  });
+
+  it('throws when neither content nor path is provided', () => {
+    expect(() => validateAttachments([{ filename: 'a.txt' }])).toThrow('exactly one of "content"');
+  });
+
+  it('throws when both content and path are provided', () => {
+    expect(() =>
+      validateAttachments([{ filename: 'a.txt', content: 'aGVsbG8=', path: '/tmp/a.txt' }]),
+    ).toThrow('exactly one of "content"');
+  });
+
+  it('throws when a single attachment exceeds the per-file limit', () => {
+    const oversized = Buffer.alloc(26 * 1024 * 1024).toString('base64');
+    expect(() => validateAttachments([{ filename: 'big.bin', content: oversized }])).toThrow(
+      'exceeds the 25MB per-file limit',
+    );
+  });
+
+  it('throws when combined attachments exceed the total size limit', () => {
+    const chunk = Buffer.alloc(15 * 1024 * 1024).toString('base64');
+    const attachments = [
+      { filename: 'a.bin', content: chunk },
+      { filename: 'b.bin', content: chunk },
+      { filename: 'c.bin', content: chunk },
+    ];
+    expect(() => validateAttachments(attachments)).toThrow('combined limit');
   });
 });
 

--- a/src/safety/validation.ts
+++ b/src/safety/validation.ts
@@ -1,5 +1,14 @@
 /** Input validation and sanitization utilities. */
 
+import type { AttachmentInput } from '../types/index.js';
+
+/** Maximum number of attachments allowed on a single outgoing email. */
+export const MAX_ATTACHMENTS = 10;
+/** Maximum size of a single attachment, in bytes (25 MB). */
+export const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024;
+/** Maximum combined size of all attachments on a single email, in bytes (40 MB). */
+export const MAX_TOTAL_ATTACHMENTS_SIZE = 40 * 1024 * 1024;
+
 /**
  * Validate and sanitize an IMAP mailbox name.
  * Rejects names containing IMAP wildcard characters (`*`, `%`) or empty strings.
@@ -117,5 +126,71 @@ export function validateLabelName(name: string): string {
 export function validateInputLength(input: string, maxLength: number, fieldName: string): void {
   if (input.length > maxLength) {
     throw new Error(`${fieldName} exceeds maximum length of ${maxLength} characters`);
+  }
+}
+
+/** Decoded byte size of a base64 string, without allocating a Buffer. */
+function base64DecodedSize(base64: string): number {
+  const cleaned = base64.replace(/\s/g, '');
+  let padding = 0;
+  if (cleaned.endsWith('==')) padding = 2;
+  else if (cleaned.endsWith('=')) padding = 1;
+  return Math.floor((cleaned.length * 3) / 4) - padding;
+}
+
+/**
+ * Validate outgoing email attachments (from send_email, reply_email, forward_email,
+ * save_draft). Enforces count and size limits and rejects unsafe filenames.
+ * Each attachment must provide exactly one of `content` (base64) or `path`.
+ * @param attachments - The attachments to validate.
+ */
+export function validateAttachments(attachments: AttachmentInput[] | undefined): void {
+  if (!attachments || attachments.length === 0) return;
+
+  if (attachments.length > MAX_ATTACHMENTS) {
+    throw new Error(
+      `Too many attachments: max ${MAX_ATTACHMENTS} allowed, got ${attachments.length}`,
+    );
+  }
+
+  let totalSize = 0;
+
+  attachments.forEach((att) => {
+    const filename = att.filename?.trim();
+    if (!filename) {
+      throw new Error('Each attachment must have a non-empty filename');
+    }
+    /* eslint-disable no-control-regex */
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — reject control chars and path separators in filenames
+    if (/[\x00-\x1F/\\]/.test(filename)) {
+      throw new Error(
+        `Attachment filename "${filename}" must not contain path separators or control characters`,
+      );
+    }
+    /* eslint-enable no-control-regex */
+
+    const hasContent = typeof att.content === 'string' && att.content.length > 0;
+    const hasPath = typeof att.path === 'string' && att.path.length > 0;
+    if (hasContent === hasPath) {
+      throw new Error(
+        `Attachment "${filename}" must provide exactly one of "content" (base64) or "path"`,
+      );
+    }
+
+    if (hasContent) {
+      const size = base64DecodedSize(att.content as string);
+      if (size > MAX_ATTACHMENT_SIZE) {
+        throw new Error(
+          `Attachment "${filename}" (${Math.round(size / 1024 / 1024)}MB) exceeds the ${MAX_ATTACHMENT_SIZE / 1024 / 1024}MB per-file limit`,
+        );
+      }
+      totalSize += size;
+    }
+  });
+
+  if (totalSize > MAX_TOTAL_ATTACHMENTS_SIZE) {
+    throw new Error(
+      `Total attachment size (${Math.round(totalSize / 1024 / 1024)}MB) exceeds the ${MAX_TOTAL_ATTACHMENTS_SIZE / 1024 / 1024}MB combined limit`,
+    );
   }
 }

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -18,6 +18,7 @@ function createMockImapClient() {
     messageDelete: vi.fn().mockResolvedValue(true),
     messageFlagsAdd: vi.fn().mockResolvedValue(true),
     messageFlagsRemove: vi.fn().mockResolvedValue(true),
+    append: vi.fn().mockResolvedValue({ uid: 42 }),
     _releaseFn: releaseFn,
   };
 }
@@ -163,6 +164,65 @@ describe('ImapService', () => {
       await service.setFlags('test', '10', 'INBOX', 'flag');
 
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // saveDraft
+  // -----------------------------------------------------------------------
+
+  describe('saveDraft', () => {
+    it('appends a plain RFC822 message when there are no attachments', async () => {
+      const result = await service.saveDraft('test', {
+        to: ['dest@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(result).toEqual({ id: 42, mailbox: 'Drafts' });
+      const [mailbox, raw, flags] = client.append.mock.calls[0];
+      expect(mailbox).toBe('Drafts');
+      expect(flags).toEqual(['\\Draft', '\\Seen']);
+      const text = (raw as Buffer).toString('utf-8');
+      expect(text).toContain('Subject: Hello');
+      expect(text).toContain('To: dest@example.com');
+      expect(text).toContain('World');
+    });
+
+    it('builds a multipart MIME message with the attachment when attachments are provided', async () => {
+      const result = await service.saveDraft('test', {
+        to: ['dest@example.com'],
+        subject: 'With attachment',
+        body: 'See attached',
+        attachments: [
+          {
+            filename: 'note.txt',
+            content: Buffer.from('hello').toString('base64'),
+            contentType: 'text/plain',
+          },
+        ],
+      });
+
+      expect(result).toEqual({ id: 42, mailbox: 'Drafts' });
+      const [, raw] = client.append.mock.calls[0];
+      const text = (raw as Buffer).toString('utf-8');
+      expect(text).toContain('multipart/mixed');
+      expect(text).toContain('Content-Disposition: attachment; filename=note.txt');
+      expect(text).toContain(Buffer.from('hello').toString('base64'));
+      expect(text).toContain('See attached');
+    });
+
+    it('rejects invalid attachments before appending', async () => {
+      await expect(
+        service.saveDraft('test', {
+          to: ['dest@example.com'],
+          subject: 'Bad',
+          body: 'oops',
+          attachments: [{ filename: 'note.txt' }],
+        }),
+      ).rejects.toThrow('exactly one of "content"');
+
+      expect(client.append).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -6,8 +6,13 @@
 
 import type { ImapFlow } from 'imapflow';
 import type { IConnectionManager } from '../connections/types.js';
-import { sanitizeMailboxName, sanitizeSearchQuery } from '../safety/validation.js';
+import {
+  sanitizeMailboxName,
+  sanitizeSearchQuery,
+  validateAttachments,
+} from '../safety/validation.js';
 import type {
+  AttachmentInput,
   AttachmentMeta,
   BulkResult,
   Contact,
@@ -22,6 +27,7 @@ import type {
   QuotaInfo,
   SenderStat,
 } from '../types/index.js';
+import { buildRawMessage, resolveAttachments } from '../utils/mail-attachments.js';
 import type { LabelStrategy } from './label-strategy.js';
 import { detectLabelStrategy } from './label-strategy.js';
 
@@ -1014,8 +1020,11 @@ export default class ImapService {
       bcc?: string[];
       html?: boolean;
       inReplyTo?: string;
+      attachments?: AttachmentInput[];
     },
   ): Promise<{ id: number; mailbox: string }> {
+    validateAttachments(options.attachments);
+
     const client = await this.connections.getImapClient(accountName);
     const account = this.connections.getAccount(accountName);
 
@@ -1024,28 +1033,42 @@ export default class ImapService {
     const drafts = mailboxes.find((mb) => mb.specialUse === '\\Drafts');
     const draftsPath = drafts?.path ?? 'Drafts';
 
-    // Construct RFC 822 message
-    const headers = [
-      `From: ${account.fullName ? `"${account.fullName}" <${account.email}>` : account.email}`,
-      `To: ${options.to.join(', ')}`,
-      `Subject: ${options.subject}`,
-      `Date: ${new Date().toUTCString()}`,
-      `MIME-Version: 1.0`,
-    ];
+    let rawMessage: Buffer;
 
-    if (options.cc?.length) headers.push(`Cc: ${options.cc.join(', ')}`);
-    if (options.bcc?.length) headers.push(`Bcc: ${options.bcc.join(', ')}`);
-    if (options.inReplyTo) headers.push(`In-Reply-To: ${options.inReplyTo}`);
+    if (options.attachments?.length) {
+      // Build a proper MIME message so attachments survive as separate parts.
+      const attachments = await resolveAttachments(options.attachments);
+      rawMessage = await buildRawMessage({
+        from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
+        to: options.to.join(', '),
+        cc: options.cc?.join(', '),
+        bcc: options.bcc?.join(', '),
+        subject: options.subject,
+        inReplyTo: options.inReplyTo,
+        attachments,
+        ...(options.html ? { html: options.body } : { text: options.body }),
+      });
+    } else {
+      // Construct RFC 822 message
+      const headers = [
+        `From: ${account.fullName ? `"${account.fullName}" <${account.email}>` : account.email}`,
+        `To: ${options.to.join(', ')}`,
+        `Subject: ${options.subject}`,
+        `Date: ${new Date().toUTCString()}`,
+        `MIME-Version: 1.0`,
+      ];
 
-    const contentType = options.html ? 'text/html; charset=utf-8' : 'text/plain; charset=utf-8';
-    headers.push(`Content-Type: ${contentType}`);
+      if (options.cc?.length) headers.push(`Cc: ${options.cc.join(', ')}`);
+      if (options.bcc?.length) headers.push(`Bcc: ${options.bcc.join(', ')}`);
+      if (options.inReplyTo) headers.push(`In-Reply-To: ${options.inReplyTo}`);
 
-    const rawMessage = `${headers.join('\r\n')}\r\n\r\n${options.body}`;
+      const contentType = options.html ? 'text/html; charset=utf-8' : 'text/plain; charset=utf-8';
+      headers.push(`Content-Type: ${contentType}`);
 
-    const appendResult = await client.append(draftsPath, Buffer.from(rawMessage), [
-      '\\Draft',
-      '\\Seen',
-    ]);
+      rawMessage = Buffer.from(`${headers.join('\r\n')}\r\n\r\n${options.body}`);
+    }
+
+    const appendResult = await client.append(draftsPath, rawMessage, ['\\Draft', '\\Seen']);
 
     return {
       id: (appendResult as unknown as { uid?: number }).uid ?? 0,

--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -124,5 +124,163 @@ describe('SmtpService', () => {
       expect(call.html).toBe('<h1>Hello</h1>');
       expect(call.text).toBeUndefined();
     });
+
+    it('decodes and sends base64 attachments', async () => {
+      await service.sendEmail('test', {
+        to: ['a@example.com'],
+        subject: 'With attachment',
+        body: 'See attached',
+        attachments: [
+          {
+            filename: 'note.txt',
+            content: Buffer.from('hello').toString('base64'),
+            contentType: 'text/plain',
+          },
+        ],
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toEqual([
+        { filename: 'note.txt', content: Buffer.from('hello'), contentType: 'text/plain' },
+      ]);
+    });
+
+    it('rejects invalid attachments before sending', async () => {
+      await expect(
+        service.sendEmail('test', {
+          to: ['a@example.com'],
+          subject: 'Bad attachment',
+          body: 'oops',
+          attachments: [{ filename: 'note.txt' }],
+        }),
+      ).rejects.toThrow('exactly one of "content"');
+
+      expect(transport.sendMail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('forwardEmail', () => {
+    function createMockImapServiceWithEmail(
+      attachments: { filename: string; mimeType: string; size: number }[],
+    ) {
+      return {
+        getEmail: vi.fn().mockResolvedValue({
+          id: '1',
+          subject: 'Original',
+          from: { address: 'sender@example.com' },
+          to: [{ address: 'test@example.com' }],
+          date: new Date().toISOString(),
+          bodyText: 'Original body',
+          attachments,
+        }),
+        downloadAttachment: vi.fn().mockResolvedValue({
+          filename: 'report.pdf',
+          mimeType: 'application/pdf',
+          size: 3,
+          contentBase64: Buffer.from('pdf').toString('base64'),
+        }),
+      } as unknown as ImapService;
+    }
+
+    it('does not include original attachments by default', async () => {
+      const imapService = createMockImapServiceWithEmail([
+        { filename: 'report.pdf', mimeType: 'application/pdf', size: 3 },
+      ]);
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.forwardEmail('test', { emailId: '1', to: ['dest@example.com'] });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toEqual([]);
+      expect(imapService.downloadAttachment).not.toHaveBeenCalled();
+    });
+
+    it('re-attaches original attachments when includeOriginalAttachments is true', async () => {
+      const imapService = createMockImapServiceWithEmail([
+        { filename: 'report.pdf', mimeType: 'application/pdf', size: 3 },
+      ]);
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.forwardEmail('test', {
+        emailId: '1',
+        to: ['dest@example.com'],
+        includeOriginalAttachments: true,
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toEqual([
+        { filename: 'report.pdf', content: Buffer.from('pdf'), contentType: 'application/pdf' },
+      ]);
+    });
+
+    it('combines original and user-supplied attachments', async () => {
+      const imapService = createMockImapServiceWithEmail([
+        { filename: 'report.pdf', mimeType: 'application/pdf', size: 3 },
+      ]);
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.forwardEmail('test', {
+        emailId: '1',
+        to: ['dest@example.com'],
+        includeOriginalAttachments: true,
+        attachments: [{ filename: 'note.txt', content: Buffer.from('hi').toString('base64') }],
+      });
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toHaveLength(2);
+      expect(call.attachments[0].filename).toBe('report.pdf');
+      expect(call.attachments[1].filename).toBe('note.txt');
+    });
+  });
+
+  describe('sendDraft', () => {
+    function createMockImapServiceWithDraft(
+      attachments: { filename: string; mimeType: string; size: number }[],
+    ) {
+      return {
+        fetchDraft: vi.fn().mockResolvedValue({
+          email: {
+            id: '5',
+            subject: 'Draft subject',
+            to: [{ address: 'dest@example.com' }],
+            bodyText: 'Draft body',
+            attachments,
+          },
+          mailbox: 'Drafts',
+        }),
+        downloadAttachment: vi.fn().mockResolvedValue({
+          filename: 'invoice.pdf',
+          mimeType: 'application/pdf',
+          size: 3,
+          contentBase64: Buffer.from('pdf').toString('base64'),
+        }),
+        deleteDraft: vi.fn().mockResolvedValue(undefined),
+      } as unknown as ImapService;
+    }
+
+    it('carries the draft attachments over when sending', async () => {
+      const imapService = createMockImapServiceWithDraft([
+        { filename: 'invoice.pdf', mimeType: 'application/pdf', size: 3 },
+      ]);
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.sendDraft('test', 5);
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toEqual([
+        { filename: 'invoice.pdf', content: Buffer.from('pdf'), contentType: 'application/pdf' },
+      ]);
+      expect(imapService.deleteDraft).toHaveBeenCalledWith('test', 5, 'Drafts');
+    });
+
+    it('sends with no attachments when the draft has none', async () => {
+      const imapService = createMockImapServiceWithDraft([]);
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.sendDraft('test', 5);
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.attachments).toEqual([]);
+    });
   });
 });

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -6,7 +6,9 @@
 
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
-import type { SendResult } from '../types/index.js';
+import { MAX_ATTACHMENT_SIZE, validateAttachments } from '../safety/validation.js';
+import type { AttachmentInput, SendResult } from '../types/index.js';
+import { resolveAttachments } from '../utils/mail-attachments.js';
 import type ImapService from './imap.service.js';
 
 export default class SmtpService {
@@ -29,12 +31,15 @@ export default class SmtpService {
       cc?: string[];
       bcc?: string[];
       html?: boolean;
+      attachments?: AttachmentInput[];
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
+    validateAttachments(options.attachments);
 
     const account = this.connections.getAccount(accountName);
     const transport = await this.connections.getSmtpTransport(accountName);
+    const attachments = await resolveAttachments(options.attachments);
 
     const result = await transport.sendMail({
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
@@ -42,6 +47,7 @@ export default class SmtpService {
       cc: options.cc?.join(', '),
       bcc: options.bcc?.join(', '),
       subject: options.subject,
+      attachments,
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
 
@@ -63,9 +69,11 @@ export default class SmtpService {
       body: string;
       replyAll?: boolean;
       html?: boolean;
+      attachments?: AttachmentInput[];
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
+    validateAttachments(options.attachments);
 
     const account = this.connections.getAccount(accountName);
     const original = await this.imapService.getEmail(accountName, options.emailId, options.mailbox);
@@ -97,6 +105,7 @@ export default class SmtpService {
       : `Re: ${original.subject}`;
 
     const transport = await this.connections.getSmtpTransport(accountName);
+    const attachments = await resolveAttachments(options.attachments);
 
     const result = await transport.sendMail({
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
@@ -105,6 +114,7 @@ export default class SmtpService {
       subject,
       inReplyTo: original.messageId,
       references: references.join(' '),
+      attachments,
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
 
@@ -126,12 +136,16 @@ export default class SmtpService {
       to: string[];
       body?: string;
       cc?: string[];
+      attachments?: AttachmentInput[];
+      includeOriginalAttachments?: boolean;
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
+    validateAttachments(options.attachments);
 
     const account = this.connections.getAccount(accountName);
-    const original = await this.imapService.getEmail(accountName, options.emailId, options.mailbox);
+    const mailbox = options.mailbox ?? 'INBOX';
+    const original = await this.imapService.getEmail(accountName, options.emailId, mailbox);
 
     const subject = original.subject.startsWith('Fwd:')
       ? original.subject
@@ -152,6 +166,33 @@ export default class SmtpService {
     const fullBody = (options.body ?? '') + forwardHeader + originalBody;
 
     const transport = await this.connections.getSmtpTransport(accountName);
+    const userAttachments = (await resolveAttachments(options.attachments)) ?? [];
+
+    let originalAttachments: { filename: string; content: Buffer; contentType: string }[] = [];
+    if (options.includeOriginalAttachments && original.attachments.length > 0) {
+      const totalOriginalSize = original.attachments.reduce((sum, a) => sum + a.size, 0);
+      if (totalOriginalSize > MAX_ATTACHMENT_SIZE) {
+        throw new Error(
+          `Original email's attachments (${Math.round(totalOriginalSize / 1024 / 1024)}MB) exceed the ${MAX_ATTACHMENT_SIZE / 1024 / 1024}MB per-file limit; forward without includeOriginalAttachments and attach selectively instead`,
+        );
+      }
+      originalAttachments = await Promise.all(
+        original.attachments.map(async (meta) => {
+          const downloaded = await this.imapService.downloadAttachment(
+            accountName,
+            options.emailId,
+            mailbox,
+            meta.filename,
+            MAX_ATTACHMENT_SIZE,
+          );
+          return {
+            filename: downloaded.filename,
+            content: Buffer.from(downloaded.contentBase64, 'base64'),
+            contentType: downloaded.mimeType,
+          };
+        }),
+      );
+    }
 
     const result = await transport.sendMail({
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
@@ -159,6 +200,7 @@ export default class SmtpService {
       cc: options.cc?.join(', '),
       subject,
       text: fullBody,
+      attachments: [...originalAttachments, ...userAttachments],
     });
 
     return {
@@ -200,6 +242,23 @@ export default class SmtpService {
     const to = draft.to.map((a) => a.address).join(', ');
     const cc = draft.cc?.map((a) => a.address).join(', ');
 
+    const attachments = await Promise.all(
+      draft.attachments.map(async (meta) => {
+        const downloaded = await this.imapService.downloadAttachment(
+          accountName,
+          String(draftId),
+          draftsPath,
+          meta.filename,
+          MAX_ATTACHMENT_SIZE,
+        );
+        return {
+          filename: downloaded.filename,
+          content: Buffer.from(downloaded.contentBase64, 'base64'),
+          contentType: downloaded.mimeType,
+        };
+      }),
+    );
+
     const result = await transport.sendMail({
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to,
@@ -207,6 +266,7 @@ export default class SmtpService {
       subject: draft.subject,
       inReplyTo: draft.inReplyTo,
       references: draft.references?.join(' '),
+      attachments,
       ...(draft.bodyHtml ? { html: draft.bodyHtml } : { text: draft.bodyText ?? '' }),
     });
 

--- a/src/tools/attachment-input.schema.ts
+++ b/src/tools/attachment-input.schema.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared zod schema for the `attachments` parameter accepted by the
+ * send_email, reply_email, forward_email, and save_draft tools.
+ */
+
+import { z } from 'zod';
+import { MAX_ATTACHMENTS } from '../safety/validation.js';
+
+const attachmentsSchema = z
+  .array(
+    z.object({
+      filename: z.string().describe('File name shown to the recipient, e.g. "invoice.pdf"'),
+      content: z
+        .string()
+        .optional()
+        .describe('Base64-encoded file content. Provide this or `path`, not both.'),
+      path: z
+        .string()
+        .optional()
+        .describe('Absolute local file path to attach. Provide this or `content`, not both.'),
+      contentType: z
+        .string()
+        .optional()
+        .describe('MIME type, e.g. "application/pdf". Guessed from the filename if omitted.'),
+    }),
+  )
+  .max(MAX_ATTACHMENTS)
+  .optional()
+  .describe('Files to attach (max 25MB each, 40MB total). Each item needs `content` or `path`.');
+
+export default attachmentsSchema;

--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -8,6 +8,7 @@ import audit from '../safety/audit.js';
 
 import type ImapService from '../services/imap.service.js';
 import type SmtpService from '../services/smtp.service.js';
+import attachmentsSchema from './attachment-input.schema.js';
 
 export default function registerDraftTools(
   server: McpServer,
@@ -32,9 +33,10 @@ export default function registerDraftTools(
       bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
       html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
       in_reply_to: z.string().optional().describe('Message-ID for threading (from get_email)'),
+      attachments: attachmentsSchema,
     },
     { readOnlyHint: false, destructiveHint: false },
-    async ({ account, to, subject, body, cc, bcc, html, in_reply_to: inReplyTo }) => {
+    async ({ account, to, subject, body, cc, bcc, html, in_reply_to: inReplyTo, attachments }) => {
       try {
         const result = await imapService.saveDraft(account, {
           to,
@@ -44,6 +46,7 @@ export default function registerDraftTools(
           bcc,
           html,
           inReplyTo,
+          attachments,
         });
 
         await audit.log('save_draft', account, { to, subject }, 'ok');
@@ -77,7 +80,7 @@ export default function registerDraftTools(
   // ---------------------------------------------------------------------------
   server.tool(
     'send_draft',
-    'Send an existing draft email and remove it from Drafts. The draft is fetched, sent via SMTP, then deleted. Use list_emails with the Drafts mailbox to find draft IDs.',
+    'Send an existing draft email and remove it from Drafts. The draft (including any attachments saved with it) is fetched, sent via SMTP, then deleted. Use list_emails with the Drafts mailbox to find draft IDs.',
     {
       account: z.string().describe('Account name from list_accounts'),
       id: z.number().int().describe('Draft email UID (from list_emails on Drafts mailbox)'),

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -8,6 +8,7 @@ import audit from '../safety/audit.js';
 import { validateInputLength } from '../safety/validation.js';
 
 import type SmtpService from '../services/smtp.service.js';
+import attachmentsSchema from './attachment-input.schema.js';
 
 export default function registerSendTools(server: McpServer, smtpService: SmtpService): void {
   // ---------------------------------------------------------------------------
@@ -15,7 +16,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
   // ---------------------------------------------------------------------------
   server.tool(
     'send_email',
-    'Send a new email. Supports plain text or HTML body, CC, and BCC.',
+    'Send a new email. Supports plain text or HTML body, CC, BCC, and file attachments.',
     {
       account: z.string().describe('Account name from list_accounts'),
       to: z.array(z.string().email()).min(1).describe('Recipient email addresses'),
@@ -24,6 +25,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       cc: z.array(z.string().email()).optional().describe('CC recipients'),
       bcc: z.array(z.string().email()).optional().describe('BCC recipients'),
       html: z.boolean().default(false).describe('Send as HTML (default: plain text)'),
+      attachments: attachmentsSchema,
     },
     { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     async (params) => {
@@ -80,6 +82,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       body: z.string().describe('Reply body content'),
       replyAll: z.boolean().default(false).describe('Reply to all recipients'),
       html: z.boolean().default(false).describe('Send as HTML'),
+      attachments: attachmentsSchema,
     },
     { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     async (params) => {
@@ -134,6 +137,11 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
       to: z.array(z.string().email()).min(1).describe('Forward to these recipients'),
       body: z.string().optional().describe('Additional message above the forwarded content'),
       cc: z.array(z.string().email()).optional().describe('CC recipients'),
+      includeOriginalAttachments: z
+        .boolean()
+        .default(false)
+        .describe("Re-attach the original email's own attachments to the forward"),
+      attachments: attachmentsSchema,
     },
     { readOnlyHint: false, destructiveHint: false, openWorldHint: true },
     async (params) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,21 @@ export interface Email extends EmailMeta {
 }
 
 // ---------------------------------------------------------------------------
+// Outgoing attachments
+// ---------------------------------------------------------------------------
+
+/**
+ * A file to attach to an outgoing email (send, reply, forward, or draft).
+ * Provide exactly one of `content` (base64) or `path` (local file path).
+ */
+export interface AttachmentInput {
+  filename: string;
+  content?: string;
+  path?: string;
+  contentType?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Results
 // ---------------------------------------------------------------------------
 

--- a/src/utils/mail-attachments.ts
+++ b/src/utils/mail-attachments.ts
@@ -1,0 +1,85 @@
+/**
+ * Converts validated AttachmentInput objects into the attachment shape
+ * expected by nodemailer's transport/MailComposer, and builds raw RFC 822
+ * messages (used for appending drafts with attachments over IMAP).
+ */
+
+import fs from 'node:fs/promises';
+// nodemailer ships MailComposer as an internal (CJS) module; it is not part
+// of the package's public "exports" map, so it must be imported by deep path.
+import MailComposer from 'nodemailer/lib/mail-composer/index.js';
+import { MAX_ATTACHMENT_SIZE } from '../safety/validation.js';
+import type { AttachmentInput } from '../types/index.js';
+
+export interface MailAttachment {
+  filename: string;
+  content?: Buffer;
+  path?: string;
+  contentType?: string;
+}
+
+/**
+ * Resolve outgoing attachments for nodemailer, decoding base64 content and
+ * verifying local file paths exist and are within the per-file size limit.
+ * @param attachments - Attachments as received from the MCP tool call.
+ * @returns Attachments in nodemailer's expected shape, or `undefined` if none.
+ */
+export async function resolveAttachments(
+  attachments: AttachmentInput[] | undefined,
+): Promise<MailAttachment[] | undefined> {
+  if (!attachments || attachments.length === 0) return undefined;
+
+  return Promise.all(
+    attachments.map(async (att): Promise<MailAttachment> => {
+      if (att.path) {
+        const stat = await fs.stat(att.path).catch(() => {
+          throw new Error(`Attachment "${att.filename}": file not found at path "${att.path}"`);
+        });
+        if (!stat.isFile()) {
+          throw new Error(`Attachment "${att.filename}": path "${att.path}" is not a file`);
+        }
+        if (stat.size > MAX_ATTACHMENT_SIZE) {
+          throw new Error(
+            `Attachment "${att.filename}" (${Math.round(stat.size / 1024 / 1024)}MB) exceeds the ${MAX_ATTACHMENT_SIZE / 1024 / 1024}MB per-file limit`,
+          );
+        }
+        return { filename: att.filename, path: att.path, contentType: att.contentType };
+      }
+
+      return {
+        filename: att.filename,
+        content: Buffer.from(att.content as string, 'base64'),
+        contentType: att.contentType,
+      };
+    }),
+  );
+}
+
+/**
+ * Build a raw RFC 822 message (headers + MIME body/attachments) without
+ * sending it, for appending directly to an IMAP folder (e.g. Drafts).
+ * @param mail - Message fields, in the same shape passed to nodemailer's `sendMail`.
+ * @returns The raw message as a Buffer.
+ */
+export async function buildRawMessage(mail: {
+  from?: string;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string;
+  attachments?: MailAttachment[];
+}): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    new MailComposer(mail).compile().build((err: Error | null, message: Buffer) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(message);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

None of the outgoing-mail tools support attachments today — `send_email`, `reply_email`, `forward_email`, and `save_draft` have no way to attach a file, even though `download_attachment` exists for reading them. This adds a symmetric write-side capability:

- New optional `attachments` parameter on `send_email`, `reply_email`, `forward_email`, and `save_draft`. Each item takes either base64 `content` or a local `path`, plus an optional `contentType`.
- New `includeOriginalAttachments` flag on `forward_email` to re-attach the original message's own attachments (off by default, so existing behavior is unchanged unless opted in).
- `save_draft` now builds a proper MIME message via nodemailer's `MailComposer` when attachments are present (unchanged plain-RFC822 path when there are none), so `send_draft` correctly re-downloads and re-attaches whatever was saved with the draft before sending.
- Validation in `safety/validation.ts`: max 10 attachments, 25MB per file, 40MB combined, filenames checked for path separators/control characters.

## Test plan

- [x] `pnpm typecheck`, `pnpm check` (biome + eslint), `pnpm test` all pass (170 tests, including new coverage in `validation.test.ts`, `smtp.service.test.ts`, and `imap.service.test.ts` for the attachment paths)
- [x] `pnpm build`, then verified `tools/list` over the real MCP stdio protocol shows the new `attachments` parameter on `send_email`, `save_draft`, and `forward_email`
- [x] End-to-end smoke test: sent a real email with a base64-encoded PDF attachment through `SmtpService` over a live SMTP connection (Ethereal test account) and confirmed the attachment arrived correctly on the received message

🤖 Generated with [Claude Code](https://claude.com/claude-code)