### PR TITLE
fix: save a Sent-mailbox copy after send_email, reply_email, forward_email, and send_draft

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -39,6 +39,7 @@ describe('Config Loader', () => {
       'MCP_EMAIL_SMTP_HOST',
       'MCP_EMAIL_READ_ONLY',
       'MCP_EMAIL_ACCOUNT_NAME',
+      'MCP_EMAIL_SENT_MAILBOX',
     ]) {
       savedEnv[key] = process.env[key];
       delete process.env[key];
@@ -74,6 +75,28 @@ describe('Config Loader', () => {
       expect(config.accounts[0].email).toBe('test@example.com');
       expect(config.accounts[0].imap.host).toBe('imap.example.com');
       expect(config.accounts[0].smtp.host).toBe('smtp.example.com');
+    });
+
+    it('reads sent_mailbox from the TOML account config', async () => {
+      const toml = `
+[[accounts]]
+name = "test"
+email = "test@example.com"
+password = "secret"
+sent_mailbox = "INBOX.Sent"
+
+[accounts.imap]
+host = "imap.example.com"
+
+[accounts.smtp]
+host = "smtp.example.com"
+`;
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(configPath, toml, 'utf-8');
+
+      const config = await loadConfig(configPath);
+
+      expect(config.accounts[0].sentMailbox).toBe('INBOX.Sent');
     });
 
     it('throws when config file does not exist', async () => {
@@ -152,6 +175,29 @@ read_only = true
       expect(config.accounts[0].email).toBe('env@example.com');
       expect(config.accounts[0].imap.host).toBe('imap.env.com');
       expect(config.accounts[0].smtp.host).toBe('smtp.env.com');
+    });
+
+    it('reads sent_mailbox from MCP_EMAIL_SENT_MAILBOX', async () => {
+      process.env.MCP_EMAIL_ADDRESS = 'env@example.com';
+      process.env.MCP_EMAIL_PASSWORD = 'env-pass';
+      process.env.MCP_EMAIL_IMAP_HOST = 'imap.env.com';
+      process.env.MCP_EMAIL_SMTP_HOST = 'smtp.env.com';
+      process.env.MCP_EMAIL_SENT_MAILBOX = 'INBOX.Sent';
+
+      const config = await loadConfig(path.join(tmpDir, 'nonexistent.toml'));
+
+      expect(config.accounts[0].sentMailbox).toBe('INBOX.Sent');
+    });
+
+    it('leaves sentMailbox undefined when MCP_EMAIL_SENT_MAILBOX is not set', async () => {
+      process.env.MCP_EMAIL_ADDRESS = 'env@example.com';
+      process.env.MCP_EMAIL_PASSWORD = 'env-pass';
+      process.env.MCP_EMAIL_IMAP_HOST = 'imap.env.com';
+      process.env.MCP_EMAIL_SMTP_HOST = 'smtp.env.com';
+
+      const config = await loadConfig(path.join(tmpDir, 'nonexistent.toml'));
+
+      expect(config.accounts[0].sentMailbox).toBeUndefined();
     });
 
     it('reads read_only from MCP_EMAIL_READ_ONLY', async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -98,6 +98,7 @@ function loadFromEnv(): RawAppConfig | null {
         username: process.env.MCP_EMAIL_USERNAME,
         password,
         oauth2,
+        sent_mailbox: process.env.MCP_EMAIL_SENT_MAILBOX,
         imap: {
           host: imapHost,
           port: parseInt(process.env.MCP_EMAIL_IMAP_PORT ?? '993', 10),
@@ -160,6 +161,7 @@ function normalizeAccount(raw: RawAccountConfig): AccountConfig {
     username: raw.username ?? raw.email,
     password: raw.password,
     oauth2: raw.oauth2 ? normalizeOAuth2(raw.oauth2) : undefined,
+    sentMailbox: raw.sent_mailbox,
     imap: {
       host: raw.imap.host,
       port: raw.imap.port,
@@ -349,6 +351,9 @@ full_name = "Your Name"
 # username defaults to email if omitted
 # username = "you@example.com"
 password = "your-app-password"
+# Only needed if your IMAP server doesn't advertise a \\Sent special-use
+# folder — sent copies are otherwise found automatically via LIST.
+# sent_mailbox = "INBOX.Sent"
 
 [accounts.imap]
 host = "imap.example.com"

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -52,6 +52,7 @@ export const AccountConfigSchema = z
     oauth2: OAuth2ConfigSchema.optional(),
     imap: ImapConfigSchema,
     smtp: SmtpConfigSchema,
+    sent_mailbox: z.string().optional(),
   })
   .refine((data) => data.password ?? data.oauth2, {
     message: 'Either password or oauth2 config is required',

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -18,11 +18,15 @@ function createMockImapClient() {
     messageDelete: vi.fn().mockResolvedValue(true),
     messageFlagsAdd: vi.fn().mockResolvedValue(true),
     messageFlagsRemove: vi.fn().mockResolvedValue(true),
+    append: vi.fn().mockResolvedValue({ uid: 42 }),
     _releaseFn: releaseFn,
   };
 }
 
-function createMockConnectionManager(mockClient: ReturnType<typeof createMockImapClient>) {
+function createMockConnectionManager(
+  mockClient: ReturnType<typeof createMockImapClient>,
+  accountOverrides: Record<string, unknown> = {},
+) {
   return {
     getAccount: vi.fn().mockReturnValue({
       name: 'test',
@@ -30,6 +34,7 @@ function createMockConnectionManager(mockClient: ReturnType<typeof createMockIma
       username: 'test@example.com',
       imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
       smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      ...accountOverrides,
     }),
     getAccountNames: vi.fn().mockReturnValue(['test']),
     getImapClient: vi.fn().mockResolvedValue(mockClient),
@@ -163,6 +168,67 @@ describe('ImapService', () => {
       await service.setFlags('test', '10', 'INBOX', 'flag');
 
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // resolveSentMailbox / appendToSent
+  // -----------------------------------------------------------------------
+
+  describe('resolveSentMailbox', () => {
+    it('picks the folder advertising the \\Sent special-use attribute', async () => {
+      client.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Sent Messages', path: 'INBOX.Sent Messages' },
+        { name: 'Sent', path: 'INBOX.Sent', specialUse: '\\Sent' },
+      ]);
+
+      const mailbox = await service.resolveSentMailbox('test');
+
+      expect(mailbox).toBe('INBOX.Sent');
+    });
+
+    it('falls back to the account-configured sentMailbox when special-use is not advertised', async () => {
+      connections = createMockConnectionManager(client, { sentMailbox: 'INBOX.Sent' });
+      service = new ImapService(connections);
+      client.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Sent Messages', path: 'INBOX.Sent Messages' },
+        { name: 'Sent', path: 'INBOX.Sent' },
+      ]);
+
+      const mailbox = await service.resolveSentMailbox('test');
+
+      expect(mailbox).toBe('INBOX.Sent');
+    });
+
+    it('falls back to "Sent" when neither special-use nor config is available', async () => {
+      client.list.mockResolvedValue([{ name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' }]);
+
+      const mailbox = await service.resolveSentMailbox('test');
+
+      expect(mailbox).toBe('Sent');
+    });
+  });
+
+  describe('appendToSent', () => {
+    it('appends the raw message to the resolved Sent mailbox, marked \\Seen', async () => {
+      client.list.mockResolvedValue([{ name: 'Sent', path: 'INBOX.Sent', specialUse: '\\Sent' }]);
+      const raw = Buffer.from('From: test@example.com\r\n\r\nHello');
+
+      const result = await service.appendToSent('test', raw);
+
+      expect(client.append).toHaveBeenCalledWith('INBOX.Sent', raw, ['\\Seen']);
+      expect(result).toEqual({ mailbox: 'INBOX.Sent', uid: 42 });
+    });
+
+    it('propagates append failures to the caller', async () => {
+      client.list.mockResolvedValue([]);
+      client.append.mockRejectedValue(new Error('mailbox does not exist'));
+
+      await expect(service.appendToSent('test', Buffer.from('x'))).rejects.toThrow(
+        'mailbox does not exist',
+      );
     });
   });
 });

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1091,6 +1091,46 @@ export default class ImapService {
   }
 
   // -------------------------------------------------------------------------
+  // Sent mailbox
+  // -------------------------------------------------------------------------
+
+  /**
+   * Resolve the account's Sent mailbox path.
+   * Prefers the folder advertised with the \Sent special-use attribute,
+   * falling back to the account's configured `sentMailbox`, then "Sent".
+   */
+  async resolveSentMailbox(accountName: string): Promise<string> {
+    const client = await this.connections.getImapClient(accountName);
+    const account = this.connections.getAccount(accountName);
+
+    const mailboxes = await client.list();
+    const sent = mailboxes.find((mb) => mb.specialUse === '\\Sent');
+    if (sent) return sent.path;
+
+    return account.sentMailbox ?? 'Sent';
+  }
+
+  /**
+   * Append a raw, already-sent MIME message to the account's Sent mailbox,
+   * marked \Seen. Used to keep a Sent-folder copy in sync with SMTP sends
+   * that don't otherwise get archived by the mail server.
+   */
+  async appendToSent(
+    accountName: string,
+    rawMessage: Buffer,
+  ): Promise<{ mailbox: string; uid?: number }> {
+    const mailbox = await this.resolveSentMailbox(accountName);
+    const client = await this.connections.getImapClient(accountName);
+
+    const appendResult = await client.append(mailbox, rawMessage, ['\\Seen']);
+
+    return {
+      mailbox,
+      uid: (appendResult as unknown as { uid?: number }).uid,
+    };
+  }
+
+  // -------------------------------------------------------------------------
   // Mailbox (folder) CRUD
   // -------------------------------------------------------------------------
 

--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -9,7 +9,7 @@ import SmtpService from './smtp.service.js';
 
 function createMockTransport() {
   return {
-    sendMail: vi.fn().mockResolvedValue({ messageId: '<test@example.com>' }),
+    sendMail: vi.fn().mockResolvedValue({ messageId: '<ignored-by-service@example.com>' }),
   };
 }
 
@@ -37,8 +37,17 @@ function createMockRateLimiter(allowed = true) {
   } as unknown as RateLimiter;
 }
 
-function createMockImapService() {
-  return {} as unknown as ImapService;
+/** Default ImapService mock: Sent-copy archiving succeeds. */
+function createMockImapService(overrides: Partial<ImapService> = {}) {
+  return {
+    appendToSent: vi.fn().mockResolvedValue({ mailbox: 'Sent', uid: 1 }),
+    ...overrides,
+  } as unknown as ImapService;
+}
+
+function getRawMessageText(transport: ReturnType<typeof createMockTransport>): string {
+  const call = transport.sendMail.mock.calls[0][0];
+  return (call.raw as Buffer).toString('utf-8');
 }
 
 // ---------------------------------------------------------------------------
@@ -49,40 +58,43 @@ describe('SmtpService', () => {
   let transport: ReturnType<typeof createMockTransport>;
   let connections: ReturnType<typeof createMockConnectionManager>;
   let rateLimiter: RateLimiter;
+  let imapService: ReturnType<typeof createMockImapService>;
   let service: SmtpService;
 
   beforeEach(() => {
     transport = createMockTransport();
     connections = createMockConnectionManager(transport);
     rateLimiter = createMockRateLimiter(true);
-    service = new SmtpService(connections, rateLimiter, createMockImapService());
+    imapService = createMockImapService();
+    service = new SmtpService(connections, rateLimiter, imapService);
   });
 
   describe('sendEmail', () => {
-    it('sends email via SMTP transport', async () => {
+    it('sends a raw MIME message via SMTP with the right headers and body', async () => {
       const result = await service.sendEmail('test', {
         to: ['recipient@example.com'],
         subject: 'Hello',
         body: 'World',
       });
 
-      expect(result).toEqual({
-        messageId: '<test@example.com>',
-        status: 'sent',
-      });
-      expect(transport.sendMail).toHaveBeenCalledWith(
-        expect.objectContaining({
-          from: '"Test User" <test@example.com>',
-          to: 'recipient@example.com',
-          subject: 'Hello',
-          text: 'World',
-        }),
-      );
+      expect(result.status).toBe('sent');
+      expect(result.messageId).toMatch(/^<[\w-]+@example\.com>$/);
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.raw).toBeInstanceOf(Buffer);
+      expect(call.envelope).toEqual({ from: 'test@example.com', to: ['recipient@example.com'] });
+
+      const text = getRawMessageText(transport);
+      expect(text).toMatch(/^From: .*Test User.*<test@example\.com>/m);
+      expect(text).toContain('To: recipient@example.com');
+      expect(text).toContain('Subject: Hello');
+      expect(text).toContain(`Message-ID: ${result.messageId}`);
+      expect(text).toContain('World');
     });
 
     it('throws when rate limited', async () => {
       rateLimiter = createMockRateLimiter(false);
-      service = new SmtpService(connections, rateLimiter, createMockImapService());
+      service = new SmtpService(connections, rateLimiter, imapService);
 
       await expect(
         service.sendEmail('test', {
@@ -95,7 +107,7 @@ describe('SmtpService', () => {
       expect(transport.sendMail).not.toHaveBeenCalled();
     });
 
-    it('includes CC and BCC when provided', async () => {
+    it('routes CC and BCC to the SMTP envelope, but keeps BCC out of the message headers', async () => {
       await service.sendEmail('test', {
         to: ['a@example.com'],
         subject: 'Test',
@@ -104,12 +116,18 @@ describe('SmtpService', () => {
         bcc: ['bcc@example.com'],
       });
 
-      expect(transport.sendMail).toHaveBeenCalledWith(
-        expect.objectContaining({
-          cc: 'cc1@example.com, cc2@example.com',
-          bcc: 'bcc@example.com',
-        }),
-      );
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.envelope.to).toEqual([
+        'a@example.com',
+        'cc1@example.com',
+        'cc2@example.com',
+        'bcc@example.com',
+      ]);
+
+      const text = getRawMessageText(transport);
+      expect(text).toContain('Cc: cc1@example.com, cc2@example.com');
+      expect(text).not.toContain('bcc@example.com');
+      expect(text).not.toMatch(/^Bcc:/m);
     });
 
     it('sends as HTML when html=true', async () => {
@@ -120,9 +138,153 @@ describe('SmtpService', () => {
         html: true,
       });
 
+      const text = getRawMessageText(transport);
+      expect(text).toContain('Content-Type: text/html');
+      expect(text).toContain('<h1>Hello</h1>');
+    });
+
+    it('archives the exact same bytes that were sent to the Sent mailbox', async () => {
+      const result = await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      const sentBytes = transport.sendMail.mock.calls[0][0].raw as Buffer;
+      const archivedBytes = (imapService.appendToSent as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as Buffer;
+
+      expect(archivedBytes).toBe(sentBytes);
+      expect(result.sentCopy).toEqual({ saved: true, mailbox: 'Sent' });
+    });
+
+    it('reports a warning instead of failing when the Sent-copy append fails', async () => {
+      imapService = createMockImapService({
+        appendToSent: vi.fn().mockRejectedValue(new Error('mailbox unavailable')),
+      });
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      const result = await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(result.status).toBe('sent');
+      expect(result.sentCopy?.saved).toBe(false);
+      expect(result.sentCopy?.warning).toContain('mailbox unavailable');
+    });
+  });
+
+  describe('replyToEmail', () => {
+    function createMockImapServiceWithEmail() {
+      return createMockImapService({
+        getEmail: vi.fn().mockResolvedValue({
+          id: '1',
+          subject: 'Original subject',
+          from: { address: 'sender@example.com' },
+          to: [{ address: 'test@example.com' }],
+          cc: [{ address: 'other@example.com' }],
+          date: new Date().toISOString(),
+          messageId: '<original@example.com>',
+          references: [],
+        }),
+      });
+    }
+
+    it('threads the reply and archives it to Sent', async () => {
+      imapService = createMockImapServiceWithEmail();
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      const result = await service.replyToEmail('test', {
+        emailId: '1',
+        body: 'Thanks!',
+      });
+
+      const text = getRawMessageText(transport);
+      expect(text).toContain('To: sender@example.com');
+      expect(text).toContain('Subject: Re: Original subject');
+      expect(text).toContain('In-Reply-To: <original@example.com>');
+      expect(text).toContain('References: <original@example.com>');
+      expect(result.sentCopy).toEqual({ saved: true, mailbox: 'Sent' });
+    });
+
+    it('includes other recipients on replyAll but excludes ourselves', async () => {
+      imapService = createMockImapServiceWithEmail();
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      await service.replyToEmail('test', {
+        emailId: '1',
+        body: 'Thanks all!',
+        replyAll: true,
+      });
+
       const call = transport.sendMail.mock.calls[0][0];
-      expect(call.html).toBe('<h1>Hello</h1>');
-      expect(call.text).toBeUndefined();
+      expect(call.envelope.to).toEqual(['sender@example.com', 'other@example.com']);
+    });
+  });
+
+  describe('forwardEmail', () => {
+    function createMockImapServiceWithEmail() {
+      return createMockImapService({
+        getEmail: vi.fn().mockResolvedValue({
+          id: '1',
+          subject: 'Original',
+          from: { address: 'sender@example.com' },
+          to: [{ address: 'test@example.com' }],
+          date: new Date().toISOString(),
+          bodyText: 'Original body',
+          attachments: [],
+        }),
+      });
+    }
+
+    it('sends the forwarded email and archives it to Sent', async () => {
+      imapService = createMockImapServiceWithEmail();
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      const result = await service.forwardEmail('test', {
+        emailId: '1',
+        to: ['dest@example.com'],
+      });
+
+      const text = getRawMessageText(transport);
+      expect(text).toContain('Subject: Fwd: Original');
+      expect(text).toContain('Original body');
+      expect(result.sentCopy).toEqual({ saved: true, mailbox: 'Sent' });
+    });
+  });
+
+  describe('sendDraft', () => {
+    function createMockImapServiceWithDraft() {
+      return createMockImapService({
+        fetchDraft: vi.fn().mockResolvedValue({
+          email: {
+            id: '5',
+            subject: 'Draft subject',
+            to: [{ address: 'dest@example.com' }],
+            bcc: [{ address: 'hidden@example.com' }],
+            bodyText: 'Draft body',
+          },
+          mailbox: 'Drafts',
+        }),
+        deleteDraft: vi.fn().mockResolvedValue(undefined),
+      });
+    }
+
+    it('sends the draft, archives it to Sent, and deletes the draft', async () => {
+      imapService = createMockImapServiceWithDraft();
+      service = new SmtpService(connections, rateLimiter, imapService);
+
+      const result = await service.sendDraft('test', 5);
+
+      const call = transport.sendMail.mock.calls[0][0];
+      expect(call.envelope.to).toEqual(['dest@example.com', 'hidden@example.com']);
+      const text = getRawMessageText(transport);
+      expect(text).not.toContain('hidden@example.com');
+
+      expect(result.sentCopy).toEqual({ saved: true, mailbox: 'Sent' });
+      expect(imapService.deleteDraft).toHaveBeenCalledWith('test', 5, 'Drafts');
     });
   });
 });

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -4,10 +4,23 @@
  * No MCP dependency — fully unit-testable.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
-import type { SendResult } from '../types/index.js';
+import type { AccountConfig, SendResult } from '../types/index.js';
+import { buildRawMessage } from '../utils/mail-message.js';
 import type ImapService from './imap.service.js';
+
+interface OutgoingMailFields {
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string;
+}
 
 export default class SmtpService {
   constructor(
@@ -32,23 +45,15 @@ export default class SmtpService {
     },
   ): Promise<SendResult> {
     this.checkRateLimit(accountName);
-
     const account = this.connections.getAccount(accountName);
-    const transport = await this.connections.getSmtpTransport(accountName);
 
-    const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
-      to: options.to.join(', '),
-      cc: options.cc?.join(', '),
-      bcc: options.bcc?.join(', '),
+    return this.composeSendAndArchive(accountName, account, {
+      to: options.to,
+      cc: options.cc,
+      bcc: options.bcc,
       subject: options.subject,
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
-
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -96,22 +101,14 @@ export default class SmtpService {
       ? original.subject
       : `Re: ${original.subject}`;
 
-    const transport = await this.connections.getSmtpTransport(accountName);
-
-    const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
-      to: to.join(', '),
-      cc: cc.length > 0 ? cc.join(', ') : undefined,
+    return this.composeSendAndArchive(accountName, account, {
+      to,
+      cc: cc.length > 0 ? cc : undefined,
       subject,
       inReplyTo: original.messageId,
       references: references.join(' '),
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
-
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -151,20 +148,12 @@ export default class SmtpService {
     const originalBody = original.bodyText ?? original.bodyHtml ?? '';
     const fullBody = (options.body ?? '') + forwardHeader + originalBody;
 
-    const transport = await this.connections.getSmtpTransport(accountName);
-
-    const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
-      to: options.to.join(', '),
-      cc: options.cc?.join(', '),
+    return this.composeSendAndArchive(accountName, account, {
+      to: options.to,
+      cc: options.cc,
       subject,
       text: fullBody,
     });
-
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -195,15 +184,11 @@ export default class SmtpService {
     );
 
     const account = this.connections.getAccount(accountName);
-    const transport = await this.connections.getSmtpTransport(accountName);
 
-    const to = draft.to.map((a) => a.address).join(', ');
-    const cc = draft.cc?.map((a) => a.address).join(', ');
-
-    const result = await transport.sendMail({
-      from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
-      to,
-      cc,
+    const result = await this.composeSendAndArchive(accountName, account, {
+      to: draft.to.map((a) => a.address),
+      cc: draft.cc?.map((a) => a.address),
+      bcc: draft.bcc?.map((a) => a.address),
       subject: draft.subject,
       inReplyTo: draft.inReplyTo,
       references: draft.references?.join(' '),
@@ -213,9 +198,64 @@ export default class SmtpService {
     // Delete the draft after successful send
     await this.imapService.deleteDraft(accountName, draftId, draftsPath);
 
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Compose once, send over SMTP, then archive the exact same bytes to Sent
+  // -------------------------------------------------------------------------
+
+  /**
+   * Builds the raw MIME message once, sends those exact bytes over SMTP,
+   * then IMAP-appends the same bytes to the account's Sent mailbox.
+   *
+   * The Sent-mailbox copy is best-effort: the mail has already been
+   * accepted by SMTP by the time we attempt it, so a failure there is
+   * reported as a warning on the result rather than thrown.
+   */
+  private async composeSendAndArchive(
+    accountName: string,
+    account: AccountConfig,
+    fields: OutgoingMailFields,
+  ): Promise<SendResult> {
+    const transport = await this.connections.getSmtpTransport(accountName);
+
+    const domain = account.email.split('@')[1] ?? 'localhost';
+    const messageId = `<${randomUUID()}@${domain}>`;
+    const from = account.fullName ? `"${account.fullName}" <${account.email}>` : account.email;
+
+    const raw = await buildRawMessage({
+      from,
+      to: fields.to.join(', '),
+      cc: fields.cc?.length ? fields.cc.join(', ') : undefined,
+      bcc: fields.bcc?.length ? fields.bcc.join(', ') : undefined,
+      subject: fields.subject,
+      text: fields.text,
+      html: fields.html,
+      inReplyTo: fields.inReplyTo,
+      references: fields.references,
+      messageId,
+    });
+
+    const envelope = {
+      from: account.email,
+      to: [...fields.to, ...(fields.cc ?? []), ...(fields.bcc ?? [])],
     };
+
+    await transport.sendMail({ raw, envelope });
+
+    const result: SendResult = { messageId, status: 'sent' };
+
+    try {
+      const { mailbox } = await this.imapService.appendToSent(accountName, raw);
+      result.sentCopy = { saved: true, mailbox };
+    } catch (err) {
+      result.sentCopy = {
+        saved: false,
+        warning: `Could not save a copy to Sent: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    return result;
   }
 }

--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -8,6 +8,7 @@ import audit from '../safety/audit.js';
 
 import type ImapService from '../services/imap.service.js';
 import type SmtpService from '../services/smtp.service.js';
+import formatSentCopyNote from './format-send-result.js';
 
 export default function registerDraftTools(
   server: McpServer,
@@ -94,7 +95,7 @@ export default function registerDraftTools(
           content: [
             {
               type: 'text' as const,
-              text: `✅ Draft sent (Message-ID: ${result.messageId}). Draft removed from folder.`,
+              text: `✅ Draft sent (Message-ID: ${result.messageId}). Draft removed from folder.${formatSentCopyNote(result)}`,
             },
           ],
         };

--- a/src/tools/format-send-result.ts
+++ b/src/tools/format-send-result.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared formatting for the Sent-mailbox-copy note appended to send/reply/
+ * forward/draft/template tool responses.
+ */
+
+import type { SendResult } from '../types/index.js';
+
+/**
+ * A trailing note describing whether a copy of the sent message was saved
+ * to the account's Sent mailbox — empty string when there's nothing to add.
+ * @param result - The result returned by an SmtpService send method.
+ */
+function formatSentCopyNote(result: SendResult): string {
+  if (!result.sentCopy) return '';
+  if (result.sentCopy.saved) return `\nSaved to: ${result.sentCopy.mailbox}`;
+  return `\n⚠️ ${result.sentCopy.warning ?? 'Could not save a copy to Sent.'}`;
+}
+
+export default formatSentCopyNote;

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -8,6 +8,7 @@ import audit from '../safety/audit.js';
 import { validateInputLength } from '../safety/validation.js';
 
 import type SmtpService from '../services/smtp.service.js';
+import formatSentCopyNote from './format-send-result.js';
 
 export default function registerSendTools(server: McpServer, smtpService: SmtpService): void {
   // ---------------------------------------------------------------------------
@@ -41,7 +42,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}\nMessage-ID: ${result.messageId}`,
+              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}\nMessage-ID: ${result.messageId}${formatSentCopyNote(result)}`,
             },
           ],
         };
@@ -95,7 +96,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Reply sent successfully!\nMessage-ID: ${result.messageId}`,
+              text: `✅ Reply sent successfully!\nMessage-ID: ${result.messageId}${formatSentCopyNote(result)}`,
             },
           ],
         };
@@ -149,7 +150,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email forwarded successfully!\nTo: ${params.to.join(', ')}\nMessage-ID: ${result.messageId}`,
+              text: `✅ Email forwarded successfully!\nTo: ${params.to.join(', ')}\nMessage-ID: ${result.messageId}${formatSentCopyNote(result)}`,
             },
           ],
         };

--- a/src/tools/templates.tool.ts
+++ b/src/tools/templates.tool.ts
@@ -11,6 +11,7 @@ import audit from '../safety/audit.js';
 import type ImapService from '../services/imap.service.js';
 import type SmtpService from '../services/smtp.service.js';
 import type TemplateService from '../services/template.service.js';
+import formatSentCopyNote from './format-send-result.js';
 
 export function registerTemplateReadTools(
   server: McpServer,
@@ -166,7 +167,7 @@ export function registerTemplateWriteTools(
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email sent from template "${template}" (Message-ID: ${sendResult.messageId})`,
+              text: `✅ Email sent from template "${template}" (Message-ID: ${sendResult.messageId})${formatSentCopyNote(sendResult)}`,
             },
           ],
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -68,6 +68,11 @@ export interface AccountConfig {
   oauth2?: OAuth2Config;
   imap: ImapConfig;
   smtp: SmtpConfig;
+  /**
+   * Fallback Sent mailbox path, used only when the server doesn't advertise
+   * a folder with the \Sent special-use attribute. E.g. "INBOX.Sent".
+   */
+  sentMailbox?: string;
 }
 
 export interface WatcherConfig {
@@ -202,6 +207,16 @@ export interface Email extends EmailMeta {
 export interface SendResult {
   messageId: string;
   status: 'sent' | 'failed';
+  /**
+   * Outcome of copying the sent message into the account's Sent mailbox.
+   * A failure here does not fail the overall send — the mail already went
+   * out over SMTP — it's surfaced here as a warning instead.
+   */
+  sentCopy?: {
+    saved: boolean;
+    mailbox?: string;
+    warning?: string;
+  };
 }
 
 export interface PaginatedResult<T> {

--- a/src/utils/mail-message.ts
+++ b/src/utils/mail-message.ts
@@ -1,0 +1,41 @@
+/**
+ * Builds a raw RFC 822 message (headers + MIME body) without sending it.
+ *
+ * Used so the exact same bytes that go out over SMTP can also be
+ * IMAP-appended to the account's Sent mailbox — the message is composed
+ * once, then reused for both, rather than re-serialized from scratch.
+ */
+
+// nodemailer ships MailComposer as an internal (CJS) module; it is not part
+// of the package's public "exports" map, so it must be imported by deep path.
+import MailComposer from 'nodemailer/lib/mail-composer/index.js';
+
+export interface MailMessageInput {
+  from?: string;
+  to?: string;
+  cc?: string;
+  bcc?: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string;
+  messageId?: string;
+}
+
+/**
+ * Compile mail fields into a raw MIME message buffer.
+ * @param mail - Message fields, in the same shape passed to nodemailer's `sendMail`.
+ * @returns The raw message as a Buffer.
+ */
+export async function buildRawMessage(mail: MailMessageInput): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    new MailComposer(mail).compile().build((err: Error | null, message: Buffer) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(message);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Mail sent through `send_email`, `reply_email`, `forward_email`, and `send_draft` was delivered fine over SMTP, but never showed up in the account's Sent mailbox — the code only ever called `transport.sendMail` and stopped there. This affects every send path in the server, including `apply_template`'s send action and scheduled sends, since they all funnel through `SmtpService`.

- Compose the raw MIME message once (nodemailer's `MailComposer`), send those exact bytes over SMTP with an explicit envelope (needed so Bcc recipients are still delivered even though Bcc is correctly excluded from the raw headers), then IMAP-append that same buffer to the Sent mailbox, marked `\Seen`. Because it's the literal bytes that were sent — including the `Message-ID` generated up front — the Sent copy always matches what the recipient received; nothing is re-serialized.
- The Sent mailbox is resolved by IMAP special-use (`\Sent`) via `LIST`, with an optional per-account `sent_mailbox` config field / `MCP_EMAIL_SENT_MAILBOX` env var as a fallback for servers that don't advertise special-use.
- The archive step is best-effort: on failure it's surfaced as a warning on the result (`result.sentCopy`) rather than failing the send, since the mail has already been accepted by SMTP by that point. All four tool responses now include a trailing note when a Sent copy couldn't be saved.
- As a side effect of switching `sendDraft` to build the message through the same path as everything else, drafts saved with a Bcc are now correctly delivered to Bcc recipients when sent (previously silently dropped).

## Test plan

- [x] `pnpm typecheck`, `pnpm check`, `pnpm test` all pass (164 tests, including new coverage in `smtp.service.test.ts` for envelope construction, Bcc exclusion from headers, Sent-copy archiving succeeding/failing without failing the send, and byte-identity between the sent and archived message; and `imap.service.test.ts`/`loader.test.ts` for `\Sent` special-use resolution, the `INBOX.Sent` vs `INBOX.Sent Messages` disambiguation, and the config/env fallback)
- [x] `pnpm build`
- [x] Verified against a real account via `LIST`: `\Sent` correctly resolves to `INBOX.Sent`, not the unrelated `INBOX.Sent Messages` folder that also exists there
- [ ] End-to-end: send a real test email through `send_email` against a live account and confirm it appears in `INBOX.Sent` immediately after, marked `\Seen` — in progress, will update this PR once complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)