### PR TITLE
feat(send): file a copy of every sent message in the Sent folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ name = "personal"
 email = "you@gmail.com"
 full_name = "Your Name"
 password = "your-app-password"
+# sent_mailbox = "INBOX.Sent Messages"   # optional, see below
 
 [accounts.imap]
 host = "imap.gmail.com"
@@ -385,6 +386,26 @@ enabled = true
 max_connections = 1
 max_messages = 100
 ```
+
+#### Where sent mail is filed
+
+A copy of every message sent through this server is filed in the account's Sent folder. The folder
+comes from the server's `\Sent` SPECIAL-USE flag (RFC 6154).
+
+Servers that do not advertise SPECIAL-USE leave the client to guess the folder by name. On a mailbox
+that has collected several sent-shaped folders over the years — `Sent`, `sent`, `Sent Messages`,
+`INBOX.Sent` — that guess can pick an empty one nobody reads. Set `sent_mailbox` on the account to
+settle it:
+
+```toml
+[[accounts]]
+name = "personal"
+email = "you@example.com"
+sent_mailbox = "INBOX.Sent Messages"
+```
+
+Use the folder's full IMAP path, as `list_mailboxes` reports it. When the copy cannot be filed, the
+message is still sent and the tool result says where it failed.
 
 #### OAuth2 _(experimental)_
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -160,6 +160,7 @@ function normalizeAccount(raw: RawAccountConfig): AccountConfig {
     username: raw.username ?? raw.email,
     password: raw.password,
     oauth2: raw.oauth2 ? normalizeOAuth2(raw.oauth2) : undefined,
+    sentMailbox: raw.sent_mailbox,
     imap: {
       host: raw.imap.host,
       port: raw.imap.port,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -50,6 +50,7 @@ export const AccountConfigSchema = z
     username: z.string().optional(),
     password: z.string().optional(),
     oauth2: OAuth2ConfigSchema.optional(),
+    sent_mailbox: z.string().optional(),
     imap: ImapConfigSchema,
     smtp: SmtpConfigSchema,
   })

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -18,6 +18,7 @@ function createMockImapClient() {
     messageDelete: vi.fn().mockResolvedValue(true),
     messageFlagsAdd: vi.fn().mockResolvedValue(true),
     messageFlagsRemove: vi.fn().mockResolvedValue(true),
+    append: vi.fn().mockResolvedValue({ uid: 7 }),
     _releaseFn: releaseFn,
   };
 }
@@ -163,6 +164,45 @@ describe('ImapService', () => {
       await service.setFlags('test', '10', 'INBOX', 'flag');
 
       expect(client.messageFlagsAdd).toHaveBeenCalledWith('10', ['\\Flagged'], { uid: true });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // appendToSent
+  // -----------------------------------------------------------------------
+
+  describe('appendToSent', () => {
+    it('files the copy in the folder the server flags as \\Sent', async () => {
+      client.list.mockResolvedValue([
+        { name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' },
+        { name: 'Drafts', path: 'INBOX.draft', specialUse: '\\Drafts' },
+        { name: 'Sent', path: 'INBOX.Sent Messages', specialUse: '\\Sent' },
+      ]);
+
+      const path = await service.appendToSent('test', Buffer.from('raw message'));
+
+      expect(path).toBe('INBOX.Sent Messages');
+      expect(client.append).toHaveBeenCalledWith(
+        'INBOX.Sent Messages',
+        Buffer.from('raw message'),
+        ['\\Seen'],
+      );
+    });
+
+    it('falls back to "Sent" when the server flags no folder', async () => {
+      client.list.mockResolvedValue([{ name: 'INBOX', path: 'INBOX', specialUse: '\\Inbox' }]);
+
+      const path = await service.appendToSent('test', Buffer.from('raw'));
+
+      expect(path).toBe('Sent');
+    });
+
+    it('marks the copy read so it does not show up as unread mail', async () => {
+      client.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', specialUse: '\\Sent' }]);
+
+      await service.appendToSent('test', Buffer.from('raw'));
+
+      expect(client.append).toHaveBeenCalledWith('Sent', expect.any(Buffer), ['\\Seen']);
     });
   });
 });

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -197,6 +197,29 @@ describe('ImapService', () => {
       expect(path).toBe('Sent');
     });
 
+    it("prefers the configured sent_mailbox over the client's guess", async () => {
+      connections.getAccount.mockReturnValue({
+        name: 'test',
+        email: 'test@example.com',
+        username: 'test@example.com',
+        sentMailbox: 'INBOX.Sent Messages',
+        imap: { host: 'imap.example.com', port: 993, tls: true, starttls: false, verifySsl: true },
+        smtp: { host: 'smtp.example.com', port: 465, tls: true, starttls: false, verifySsl: true },
+      });
+      client.list.mockResolvedValue([
+        { name: 'Sent', path: 'INBOX.INBOX.Sent', specialUse: '\\Sent' },
+      ]);
+
+      const path = await service.appendToSent('test', Buffer.from('raw'));
+
+      expect(path).toBe('INBOX.Sent Messages');
+      expect(client.append).toHaveBeenCalledWith('INBOX.Sent Messages', expect.any(Buffer), [
+        '\\Seen',
+      ]);
+      // the override settles it, so there is nothing to look up
+      expect(client.list).not.toHaveBeenCalled();
+    });
+
     it('marks the copy read so it does not show up as unread mail', async () => {
       client.list.mockResolvedValue([{ name: 'Sent', path: 'Sent', specialUse: '\\Sent' }]);
 

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1088,10 +1088,17 @@ export default class ImapService {
    */
   async appendToSent(accountName: string, raw: Buffer): Promise<string> {
     const client = await this.connections.getImapClient(accountName);
+    const account = this.connections.getAccount(accountName);
 
-    const mailboxes = await client.list();
-    const sent = mailboxes.find((mb) => mb.specialUse === '\\Sent');
-    const sentPath = sent?.path ?? 'Sent';
+    // A server that does not advertise SPECIAL-USE makes the client guess the
+    // Sent folder from its name, and the guess loses on a mailbox that carries
+    // several sent-shaped folders left by different clients over the years — it
+    // can land on an empty one nobody reads. `sent_mailbox` settles it.
+    let sentPath = account.sentMailbox;
+    if (!sentPath) {
+      const mailboxes = await client.list();
+      sentPath = mailboxes.find((mb) => mb.specialUse === '\\Sent')?.path ?? 'Sent';
+    }
 
     await client.append(sentPath, raw, ['\\Seen']);
 

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -1079,6 +1079,25 @@ export default class ImapService {
     return { email, mailbox: draftsPath };
   }
 
+  /**
+   * File a copy of an outgoing message in the account's Sent folder.
+   *
+   * SMTP only hands the message to the next hop; nothing about sending puts a
+   * copy in the mailbox. Mail clients APPEND it themselves, so a server-side
+   * sender that skips this leaves no record of what it sent.
+   */
+  async appendToSent(accountName: string, raw: Buffer): Promise<string> {
+    const client = await this.connections.getImapClient(accountName);
+
+    const mailboxes = await client.list();
+    const sent = mailboxes.find((mb) => mb.specialUse === '\\Sent');
+    const sentPath = sent?.path ?? 'Sent';
+
+    await client.append(sentPath, raw, ['\\Seen']);
+
+    return sentPath;
+  }
+
   /** Delete a draft after it has been sent. */
   async deleteDraft(accountName: string, emailId: number, mailbox: string): Promise<void> {
     const client = await this.connections.getImapClient(accountName);

--- a/src/services/smtp.service.test.ts
+++ b/src/services/smtp.service.test.ts
@@ -38,7 +38,9 @@ function createMockRateLimiter(allowed = true) {
 }
 
 function createMockImapService() {
-  return {} as unknown as ImapService;
+  return {
+    appendToSent: vi.fn().mockResolvedValue('INBOX.Sent'),
+  } as unknown as ImapService;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,13 +51,15 @@ describe('SmtpService', () => {
   let transport: ReturnType<typeof createMockTransport>;
   let connections: ReturnType<typeof createMockConnectionManager>;
   let rateLimiter: RateLimiter;
+  let imapService: ReturnType<typeof createMockImapService>;
   let service: SmtpService;
 
   beforeEach(() => {
     transport = createMockTransport();
     connections = createMockConnectionManager(transport);
     rateLimiter = createMockRateLimiter(true);
-    service = new SmtpService(connections, rateLimiter, createMockImapService());
+    imapService = createMockImapService();
+    service = new SmtpService(connections, rateLimiter, imapService);
   });
 
   describe('sendEmail', () => {
@@ -69,6 +73,7 @@ describe('SmtpService', () => {
       expect(result).toEqual({
         messageId: '<test@example.com>',
         status: 'sent',
+        archivedTo: 'INBOX.Sent',
       });
       expect(transport.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -123,6 +128,88 @@ describe('SmtpService', () => {
       const call = transport.sendMail.mock.calls[0][0];
       expect(call.html).toBe('<h1>Hello</h1>');
       expect(call.text).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Sent copy
+  // -----------------------------------------------------------------------
+
+  describe('filing a copy in Sent', () => {
+    it('files every sent message and reports the folder', async () => {
+      const result = await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(imapService.appendToSent).toHaveBeenCalledOnce();
+      expect(result.archivedTo).toBe('INBOX.Sent');
+      expect(result.archiveError).toBeUndefined();
+    });
+
+    it('files a copy carrying the Message-ID that SMTP returned', async () => {
+      transport.sendMail.mockResolvedValue({ messageId: '<real-id@example.com>' });
+
+      await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      const [, raw] = (imapService.appendToSent as unknown as ReturnType<typeof vi.fn>).mock
+        .calls[0] as [string, Buffer];
+      expect(raw.toString()).toContain('Message-ID: <real-id@example.com>');
+      expect(raw.toString()).toContain('Subject: Hello');
+    });
+
+    it('reports a send as sent even when filing the copy fails', async () => {
+      (imapService.appendToSent as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('NO [TRYCREATE] Mailbox does not exist'),
+      );
+
+      const result = await service.sendEmail('test', {
+        to: ['recipient@example.com'],
+        subject: 'Hello',
+        body: 'World',
+      });
+
+      expect(result.status).toBe('sent');
+      expect(result.messageId).toBe('<test@example.com>');
+      expect(result.archivedTo).toBeNull();
+      expect(result.archiveError).toContain('Mailbox does not exist');
+    });
+
+    it('files a copy for replies, forwards and drafts too, not only plain sends', async () => {
+      const imap = imapService as unknown as {
+        appendToSent: ReturnType<typeof vi.fn>;
+        getEmail: ReturnType<typeof vi.fn>;
+        fetchDraft: ReturnType<typeof vi.fn>;
+        deleteDraft: ReturnType<typeof vi.fn>;
+      };
+      imap.getEmail = vi.fn().mockResolvedValue({
+        from: { address: 'them@example.com' },
+        to: [{ address: 'test@example.com' }],
+        subject: 'Original',
+        messageId: '<orig@example.com>',
+        date: '2026-01-01',
+        bodyText: 'body',
+      });
+      imap.fetchDraft = vi.fn().mockResolvedValue({
+        email: {
+          to: [{ address: 'recipient@example.com' }],
+          subject: 'Draft',
+          bodyText: 'draft body',
+        },
+        mailbox: 'INBOX.Drafts',
+      });
+      imap.deleteDraft = vi.fn().mockResolvedValue(undefined);
+
+      await service.replyToEmail('test', { emailId: '1', body: 'reply' });
+      await service.forwardEmail('test', { emailId: '1', to: ['other@example.com'] });
+      await service.sendDraft('test', 1);
+
+      expect(imap.appendToSent).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/src/services/smtp.service.ts
+++ b/src/services/smtp.service.ts
@@ -4,6 +4,9 @@
  * No MCP dependency — fully unit-testable.
  */
 
+import MailComposer from 'nodemailer/lib/mail-composer/index.js';
+import type Mail from 'nodemailer/lib/mailer/index.js';
+
 import type { IConnectionManager } from '../connections/types.js';
 import type RateLimiter from '../safety/rate-limiter.js';
 import type { SendResult } from '../types/index.js';
@@ -34,9 +37,8 @@ export default class SmtpService {
     this.checkRateLimit(accountName);
 
     const account = this.connections.getAccount(accountName);
-    const transport = await this.connections.getSmtpTransport(accountName);
 
-    const result = await transport.sendMail({
+    return this.dispatch(accountName, {
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to: options.to.join(', '),
       cc: options.cc?.join(', '),
@@ -44,11 +46,6 @@ export default class SmtpService {
       subject: options.subject,
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
-
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -96,9 +93,7 @@ export default class SmtpService {
       ? original.subject
       : `Re: ${original.subject}`;
 
-    const transport = await this.connections.getSmtpTransport(accountName);
-
-    const result = await transport.sendMail({
+    return this.dispatch(accountName, {
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to: to.join(', '),
       cc: cc.length > 0 ? cc.join(', ') : undefined,
@@ -107,11 +102,6 @@ export default class SmtpService {
       references: references.join(' '),
       ...(options.html ? { html: options.body } : { text: options.body }),
     });
-
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
   }
 
   // -------------------------------------------------------------------------
@@ -151,20 +141,48 @@ export default class SmtpService {
     const originalBody = original.bodyText ?? original.bodyHtml ?? '';
     const fullBody = (options.body ?? '') + forwardHeader + originalBody;
 
-    const transport = await this.connections.getSmtpTransport(accountName);
-
-    const result = await transport.sendMail({
+    return this.dispatch(accountName, {
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to: options.to.join(', '),
       cc: options.cc?.join(', '),
       subject,
       text: fullBody,
     });
+  }
 
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
+  // -------------------------------------------------------------------------
+  // Send + file a copy
+  // -------------------------------------------------------------------------
+
+  /**
+   * Hand the message to SMTP, then file a copy in Sent.
+   *
+   * `date` and `messageId` are pinned so the filed copy is the message that
+   * actually went out, not a lookalike rebuilt from the same fields — a reply
+   * threads against that Message-ID.
+   */
+  private async dispatch(accountName: string, message: Mail.Options): Promise<SendResult> {
+    const transport = await this.connections.getSmtpTransport(accountName);
+
+    const date = new Date();
+    const info = await transport.sendMail({ ...message, date });
+    const messageId = info.messageId ?? '';
+
+    try {
+      const raw = await new MailComposer({ ...message, date, messageId }).compile().build();
+      const archivedTo = await this.imapService.appendToSent(accountName, raw);
+      return { messageId, status: 'sent', archivedTo };
+    } catch (err) {
+      // The message is already delivered to SMTP. Throwing here would report a
+      // send that happened as a failure, so report the missing copy instead —
+      // silence is what made sent mail untraceable in the first place.
+      return {
+        messageId,
+        status: 'sent',
+        archivedTo: null,
+        archiveError: err instanceof Error ? err.message : String(err),
+      };
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -195,12 +213,11 @@ export default class SmtpService {
     );
 
     const account = this.connections.getAccount(accountName);
-    const transport = await this.connections.getSmtpTransport(accountName);
 
     const to = draft.to.map((a) => a.address).join(', ');
     const cc = draft.cc?.map((a) => a.address).join(', ');
 
-    const result = await transport.sendMail({
+    const result = await this.dispatch(accountName, {
       from: account.fullName ? `"${account.fullName}" <${account.email}>` : account.email,
       to,
       cc,
@@ -213,9 +230,6 @@ export default class SmtpService {
     // Delete the draft after successful send
     await this.imapService.deleteDraft(accountName, draftId, draftsPath);
 
-    return {
-      messageId: result.messageId ?? '',
-      status: 'sent',
-    };
+    return result;
   }
 }

--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -5,9 +5,9 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import audit from '../safety/audit.js';
-
 import type ImapService from '../services/imap.service.js';
 import type SmtpService from '../services/smtp.service.js';
+import sentCopyNote from '../utils/sent-copy.js';
 
 export default function registerDraftTools(
   server: McpServer,
@@ -94,7 +94,7 @@ export default function registerDraftTools(
           content: [
             {
               type: 'text' as const,
-              text: `✅ Draft sent (Message-ID: ${result.messageId}). Draft removed from folder.`,
+              text: `✅ Draft sent (Message-ID: ${result.messageId}). Draft removed from folder.${sentCopyNote(result)}`,
             },
           ],
         };

--- a/src/tools/send.tool.ts
+++ b/src/tools/send.tool.ts
@@ -6,8 +6,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import audit from '../safety/audit.js';
 import { validateInputLength } from '../safety/validation.js';
-
 import type SmtpService from '../services/smtp.service.js';
+import sentCopyNote from '../utils/sent-copy.js';
 
 export default function registerSendTools(server: McpServer, smtpService: SmtpService): void {
   // ---------------------------------------------------------------------------
@@ -41,7 +41,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}\nMessage-ID: ${result.messageId}`,
+              text: `✅ Email sent successfully!\nTo: ${params.to.join(', ')}\nSubject: ${params.subject}\nMessage-ID: ${result.messageId}${sentCopyNote(result)}`,
             },
           ],
         };
@@ -95,7 +95,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Reply sent successfully!\nMessage-ID: ${result.messageId}`,
+              text: `✅ Reply sent successfully!\nMessage-ID: ${result.messageId}${sentCopyNote(result)}`,
             },
           ],
         };
@@ -149,7 +149,7 @@ export default function registerSendTools(server: McpServer, smtpService: SmtpSe
           content: [
             {
               type: 'text' as const,
-              text: `✅ Email forwarded successfully!\nTo: ${params.to.join(', ')}\nMessage-ID: ${result.messageId}`,
+              text: `✅ Email forwarded successfully!\nTo: ${params.to.join(', ')}\nMessage-ID: ${result.messageId}${sentCopyNote(result)}`,
             },
           ],
         };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -202,6 +202,10 @@ export interface Email extends EmailMeta {
 export interface SendResult {
   messageId: string;
   status: 'sent' | 'failed';
+  /** Folder the Sent copy landed in, or null when filing it failed. */
+  archivedTo?: string | null;
+  /** Why the Sent copy could not be filed. Set only when archivedTo is null. */
+  archiveError?: string;
 }
 
 export interface PaginatedResult<T> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,12 @@ export interface AccountConfig {
   username: string;
   password?: string;
   oauth2?: OAuth2Config;
+  /**
+   * Folder to file sent mail in. Set this when the server does not advertise
+   * SPECIAL-USE — the client then guesses the Sent folder by name, and on a
+   * mailbox carrying several sent-shaped folders the guess picks the wrong one.
+   */
+  sentMailbox?: string;
   imap: ImapConfig;
   smtp: SmtpConfig;
 }

--- a/src/utils/sent-copy.ts
+++ b/src/utils/sent-copy.ts
@@ -1,0 +1,15 @@
+/**
+ * Human-readable note about the Sent copy that accompanies every send result.
+ */
+
+import type { SendResult } from '../types/index.js';
+
+export default function sentCopyNote(result: SendResult): string {
+  if (result.archivedTo) {
+    return `\nCopy filed in: ${result.archivedTo}`;
+  }
+
+  // Say it out loud. A send that leaves no record looks identical to one that
+  // does, and the difference only surfaces weeks later when someone looks.
+  return `\n⚠️ No copy filed in Sent${result.archiveError ? ` (${result.archiveError})` : ''} — this message is not in your mailbox.`;
+}


### PR DESCRIPTION
## Problem

SMTP only hands a message to the next hop — nothing about sending puts a copy in the mailbox. Mail clients do that themselves with an IMAP `APPEND`. This server never did, so **every** message it sent (`send_message`, `reply`, `forward`, `send_draft`) left no trace in the user's mailbox.

`send_draft` makes it worse: it deletes the draft after sending, so the last remaining copy disappears too.

Reproduced against a live account: a message sent through `send_draft` was delivered (SMTP returned a Message-ID) but existed in none of the account's Sent folders afterwards. The user cannot see what was sent, and an incoming reply has nothing to thread against.

The whole source contained exactly one `client.append()` — in `saveDraft`, to the Drafts folder.

## Change

The four send paths each built their own `getSmtpTransport` → `sendMail` → `SendResult` block, so the copy goes in one new private `dispatch()` that all four now share. Net simplification: the four duplicates collapse into one.

- `ImapService.appendToSent()` resolves the target from the server's `\Sent` SPECIAL-USE flag (RFC 6154) — the same way `saveDraft` already resolves `\Drafts` — and falls back to `Sent`.
- `date` and `messageId` are pinned across send and compose, so the filed copy is the message that actually went out rather than a lookalike rebuilt from the same fields. A reply threads against that Message-ID.
- Filing runs **after** delivery, so a failure there can never mean "not sent". It is reported rather than thrown: `status` stays `sent`, `archivedTo` is `null`, and `archiveError` carries the reason, which the tools print. A silent miss is what made sent mail untraceable in the first place.

## Verification

- `npm run typecheck` — clean
- `npm run check` (biome + eslint) — clean
- `npx vitest run` — 157/157 passing
- `npm run build` — exit 0

Three hand-mutations to confirm the new tests actually detect the defect, all killed:

| Mutation | Result |
|---|---|
| `appendToSent` looks for `\Drafts` instead of `\Sent` | 1 failed |
| `dispatch` skips `appendToSent` | 4 failed |
| the `catch` rethrows instead of reporting | 1 failed |

## Second commit: the flag alone is not enough

Filing the copy resolves the folder from the `\Sent` SPECIAL-USE flag. Testing the first commit against a live OVH MX Plan account showed why that is not sufficient on its own:

```
CAPABILITY contains SPECIAL-USE: False
(\HasChildren)   "." INBOX
(\HasNoChildren) "." INBOX.Drafts
```

The server advertises no SPECIAL-USE capability and returns no special-use attributes in `LIST`, so the client falls back to guessing the folder by name. On that account the guess resolved `\Sent` to `INBOX.INBOX.Sent`, which holds **0 messages**, while the live sent mail sits in `INBOX.Sent Messages` (37). The copy would have been filed where nobody looks — green, and useless.

That mailbox has seven sent/draft/trash-shaped folders accumulated from different clients over the years, which is what defeats a name-based guess. `sent_mailbox` on the account settles it. Left unset, nothing changes and the flag still decides.

## Two deliberate choices, flagged for review

1. **`archivedTo?: string | null` is optional on purpose.** `SendResult` is an exported type of a published package, so making the field required would be a breaking change for outside consumers. Happy to tighten it to required if you would rather take that.
2. **The `\Sent` lookup is a third inline copy** of the special-use resolution already in `saveDraft` and `fetchDraft`. Extracting a shared `resolveSpecialUseFolder(mailboxes, flag, fallback)` would clear the bar at three call sites, but it would mean editing two methods this bug fix does not otherwise touch. Left out to keep the PR reviewable — glad to do it here or in a follow-up, your call.
