### PR TITLE
feat(config): resolve account passwords via password_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,8 @@ For single-account setups (overrides config file):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MCP_EMAIL_ADDRESS` | *required* | Email address |
-| `MCP_EMAIL_PASSWORD` | *required* | Password or app password |
+| `MCP_EMAIL_PASSWORD` | *required*¹ | Password or app password |
+| `MCP_EMAIL_PASSWORD_COMMAND` | *required*¹ | Shell command printing the password to stdout (see [Resolving the password from a command](#resolving-the-password-from-a-command)) |
 | `MCP_EMAIL_IMAP_HOST` | *required* | IMAP server hostname |
 | `MCP_EMAIL_SMTP_HOST` | *required* | SMTP server hostname |
 | `MCP_EMAIL_ACCOUNT_NAME` | `default` | Account name |
@@ -472,6 +473,8 @@ For single-account setups (overrides config file):
 | `MCP_EMAIL_SMTP_POOL_MAX_CONNECTIONS` | `1` | Max pooled SMTP connections |
 | `MCP_EMAIL_SMTP_POOL_MAX_MESSAGES` | `100` | Max messages per pooled connection |
 | `MCP_EMAIL_RATE_LIMIT` | `10` | Max sends per minute |
+
+¹ One of `MCP_EMAIL_PASSWORD`, `MCP_EMAIL_PASSWORD_COMMAND`, or the OAuth2 variables is required.
 
 ### Email Scheduling
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ Commands:
 
 Located at `$XDG_CONFIG_HOME/email-mcp/config.toml` (default: `~/.config/email-mcp/config.toml`).
 
+Each account authenticates with exactly one of `password`, `password_command`, or an `[accounts.oauth2]` block.
+
 ```toml
 [settings]
 rate_limit = 10  # max emails per minute per account
@@ -385,6 +387,35 @@ enabled = true
 max_connections = 1
 max_messages = 100
 ```
+
+#### Resolving the password from a command
+
+Instead of `password`, set `password_command` to any shell command that prints the
+password to **stdout**. Trailing whitespace is trimmed. This keeps secrets in your
+password manager instead of in plaintext in `config.toml`.
+
+```toml
+[[accounts]]
+name = "personal"
+email = "you@gmail.com"
+
+# macOS Keychain
+password_command = "security find-generic-password -s email-mcp-personal -w"
+
+# Bitwarden CLI (requires an unlocked vault; BW_SESSION is inherited from the environment)
+# password_command = "bw get password personal-email"
+
+# 1Password CLI
+# password_command = "op read 'op://Private/personal-email/password'"
+```
+
+- The command runs **once at startup**, via `/bin/sh -c`, in parallel across accounts.
+- Your vault must already be unlocked. The command cannot prompt on stdin and is
+  killed after **10 seconds**.
+- The password must go to stdout. Anything the command writes to stderr may be
+  echoed back in error messages to help you debug, so do not print secrets there.
+- If both `password` and `password_command` are set, `password_command` wins.
+- Rotating the password requires restarting the server.
 
 #### OAuth2 _(experimental)_
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,7 @@ You should receive a response within 48 hours. If the issue is confirmed, a fix 
 email-mcp handles sensitive email credentials and message content. The project includes several security measures:
 
 - **No credential storage** — passwords and tokens are read from your local config file or environment variables at runtime
+- **Passwords need not be stored at all** — `password_command` resolves an account password by running an external command (a password manager CLI, the macOS Keychain) at startup, so no secret is written to `config.toml`
 - **Audit logging** — all write operations are logged with automatic redaction of sensitive fields (passwords, email body content)
 - **Rate limiting** — configurable rate limits on send operations (default: 10/minute)
 - **Read-only mode** — can be configured to disable all write operations
@@ -26,7 +27,15 @@ email-mcp handles sensitive email credentials and message content. The project i
 
 ## Best Practices for Users
 
-- Use app-specific passwords instead of your main account password
+- Prefer `password_command` over a plaintext `password` in `config.toml`, so the
+  secret stays in your password manager or the OS keychain:
+  ```toml
+  password_command = "security find-generic-password -s email-mcp-personal -w"
+  ```
+  The command must print the password to **stdout** only — anything it writes to
+  stderr may be quoted back in error messages.
+- Use app-specific passwords instead of your main account password — they are
+  revocable individually and cannot be used to take over the account
 - Enable OAuth2 authentication where supported (Gmail, Outlook)
 - Review the audit log at `~/.local/share/email-mcp/audit.jsonl`
 - Use `read_only: true` in config if you only need read access

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,7 @@ You should receive a response within 48 hours. If the issue is confirmed, a fix 
 email-mcp handles sensitive email credentials and message content. The project includes several security measures:
 
 - **No credential storage** — passwords and tokens are read from your local config file or environment variables at runtime
+- **Config written owner-only** — `saveConfig` creates the config directory `0700` and the file `0600`, and tightens an existing file that was left more permissive
 - **Passwords need not be stored at all** — `password_command` resolves an account password by running an external command (a password manager CLI, the macOS Keychain) at startup, so no secret is written to `config.toml`
 - **Audit logging** — all write operations are logged with automatic redaction of sensitive fields (passwords, email body content)
 - **Rate limiting** — configurable rate limits on send operations (default: 10/minute)

--- a/src/cli/account-commands.test.ts
+++ b/src/cli/account-commands.test.ts
@@ -1,0 +1,40 @@
+import { credentialFields } from './account-commands.js';
+
+describe('credentialFields', () => {
+  it('writes password_command and clears password when a command was given', () => {
+    const fields = credentialFields({
+      username: 'u',
+      password: '',
+      passwordCommand: 'printf secret',
+    });
+
+    expect(fields.password_command).toBe('printf secret');
+    expect(fields.password).toBeUndefined();
+  });
+
+  it('writes password and clears password_command when a password was typed', () => {
+    const fields = credentialFields({ username: 'u', password: 'typed' });
+
+    expect(fields.password).toBe('typed');
+    expect(fields.password_command).toBeUndefined();
+  });
+
+  // The regression that matters: an `account edit` touching only the display
+  // name must leave the account's credential source alone. Returning any key
+  // here would clobber whatever buildRawAccount spread in from the existing
+  // account — password_command and oauth2 included.
+  it('returns no keys when neither credential was collected', () => {
+    expect(credentialFields({ username: 'u', password: '' })).toEqual({});
+  });
+
+  it('prefers the command when both are somehow present', () => {
+    const fields = credentialFields({
+      username: 'u',
+      password: 'stale',
+      passwordCommand: 'printf fresh',
+    });
+
+    expect(fields.password_command).toBe('printf fresh');
+    expect(fields.password).toBeUndefined();
+  });
+});

--- a/src/cli/account-commands.ts
+++ b/src/cli/account-commands.ts
@@ -22,6 +22,7 @@ import {
 } from '@clack/prompts';
 
 import { CONFIG_FILE, configExists, loadRawConfig, saveConfig } from '../config/loader.js';
+import resolvePasswordCommand from '../config/password-command.js';
 import type { RawAccountConfig, RawAppConfig } from '../config/schema.js';
 import { AppConfigFileSchema } from '../config/schema.js';
 import ConnectionManager from '../connections/manager.js';
@@ -230,13 +231,22 @@ async function promptAccountIdentity(defaults?: {
   return { name, email, fullName };
 }
 
+/** Credentials collected from the prompts. Exactly one source is populated. */
+interface Credentials {
+  username: string;
+  password: string;
+  passwordCommand?: string;
+}
+
 /**
- * Prompt for credentials (username, password).
+ * Prompt for credentials — either a literal password or a command that prints
+ * one, so a secret need never be written to config.toml.
  */
 async function promptCredentials(defaults?: {
   username?: string;
   email?: string;
-}): Promise<{ username: string; password: string }> {
+  passwordCommand?: string;
+}): Promise<Credentials> {
   const username = await text({
     message: 'Username',
     placeholder: defaults?.email ?? 'you@example.com',
@@ -244,6 +254,32 @@ async function promptCredentials(defaults?: {
     initialValue: defaults?.username ?? defaults?.email,
   });
   assertNotCancel(username);
+
+  const source = await select({
+    message: 'Where does the password come from?',
+    options: [
+      {
+        value: 'command',
+        label: 'A command',
+        hint: 'password manager CLI — nothing secret is written to config.toml',
+      },
+      { value: 'password', label: 'Type it', hint: 'stored in plain text in config.toml' },
+    ],
+    initialValue: defaults?.passwordCommand ? 'command' : 'password',
+  });
+  assertNotCancel(source);
+
+  if (source === 'command') {
+    const passwordCommand = await text({
+      message: 'Command printing the password to stdout',
+      placeholder: 'security find-generic-password -s email-mcp-personal -w',
+      defaultValue: defaults?.passwordCommand,
+      initialValue: defaults?.passwordCommand,
+      validate: (v) => (!v || v.trim().length === 0 ? 'Command is required' : undefined),
+    });
+    assertNotCancel(passwordCommand);
+    return { username, password: '', passwordCommand };
+  }
 
   const password = await p_password({
     message: 'Password / App Password',
@@ -306,17 +342,24 @@ async function resolveServerSettings(
 /**
  * Build a normalized AccountConfig for connection testing.
  */
-function buildTestAccount(
+async function buildTestAccount(
   identity: { name: string; email: string; fullName: string },
-  creds: { username: string; password: string },
+  creds: Credentials,
   server: ServerSettings,
-): AccountConfig {
+): Promise<AccountConfig> {
+  // Resolve up front, so the connection test exercises the real credential
+  // rather than silently testing an empty password.
+  const password = creds.passwordCommand
+    ? await resolvePasswordCommand(creds.passwordCommand, identity.name)
+    : creds.password;
+
   return {
     name: identity.name,
     email: identity.email,
     fullName: identity.fullName || undefined,
     username: creds.username || identity.email,
-    password: creds.password,
+    password,
+    passwordCommand: creds.passwordCommand,
     imap: {
       host: server.imapHost,
       port: server.imapPort,
@@ -377,12 +420,23 @@ async function testConnections(account: AccountConfig): Promise<boolean> {
   return true;
 }
 
+/** The credential keys to write, given the source the user chose. */
+export function credentialFields(creds: Credentials): Partial<RawAccountConfig> {
+  if (creds.passwordCommand) {
+    return { password: undefined, password_command: creds.passwordCommand };
+  }
+  if (creds.password) {
+    return { password: creds.password, password_command: undefined };
+  }
+  return {};
+}
+
 /**
  * Build a RawAccountConfig from collected data.
  */
 function buildRawAccount(
   identity: { name: string; email: string; fullName: string },
-  creds: { username: string; password: string },
+  creds: Credentials,
   server: ServerSettings,
   existingAccount?: RawAccountConfig,
 ): RawAccountConfig {
@@ -394,12 +448,11 @@ function buildRawAccount(
     email: identity.email,
     full_name: identity.fullName || undefined,
     username: creds.username || identity.email,
-    // Only write a plaintext password when one was actually supplied, so a
-    // password_command or oauth2 account is not downgraded by an edit that
-    // never touched its credentials. When one *is* supplied, drop
-    // password_command — it would otherwise take precedence at load time and
-    // silently defeat the password the user just typed.
-    ...(creds.password ? { password: creds.password, password_command: undefined } : {}),
+    // Write exactly the credential source the user chose, clearing the other so
+    // a stale field cannot take precedence at load time. When neither was
+    // collected (an edit that never touched credentials), both are left to the
+    // spread above, so password_command and oauth2 survive.
+    ...credentialFields(creds),
     imap: {
       ...existingAccount?.imap,
       host: server.imapHost,
@@ -495,7 +548,7 @@ async function addAccount(): Promise<void> {
   const creds = await promptCredentials({ email: identity.email });
 
   // 4. Test connections
-  const testAccount = buildTestAccount(identity, creds, server);
+  const testAccount = await buildTestAccount(identity, creds, server);
   const ok = await testConnections(testAccount);
   if (!ok) return;
 
@@ -652,9 +705,10 @@ async function editAccount(nameArg?: string): Promise<void> {
     smtpPoolMaxConnections: current.smtp.pool?.max_connections ?? 1,
     smtpPoolMaxMessages: current.smtp.pool?.max_messages ?? 100,
   };
-  let creds = {
+  let creds: Credentials = {
     username: current.username ?? current.email,
     password: current.password ?? '',
+    passwordCommand: current.password_command,
   };
 
   if (fields === 'identity' || fields === 'all') {
@@ -681,6 +735,7 @@ async function editAccount(nameArg?: string): Promise<void> {
     creds = await promptCredentials({
       username: creds.username,
       email: identity.email,
+      passwordCommand: creds.passwordCommand,
     });
   }
 
@@ -692,7 +747,7 @@ async function editAccount(nameArg?: string): Promise<void> {
   assertNotCancel(shouldTest);
 
   if (shouldTest) {
-    const testAccount = buildTestAccount(identity, creds, server);
+    const testAccount = await buildTestAccount(identity, creds, server);
     const ok = await testConnections(testAccount);
     if (!ok) return;
   }

--- a/src/cli/account-commands.ts
+++ b/src/cli/account-commands.ts
@@ -384,26 +384,37 @@ function buildRawAccount(
   identity: { name: string; email: string; fullName: string },
   creds: { username: string; password: string },
   server: ServerSettings,
+  existingAccount?: RawAccountConfig,
 ): RawAccountConfig {
   return {
+    // Spread the existing account first so fields the prompts never collect
+    // (password_command, oauth2, ...) survive an edit instead of being dropped.
+    ...existingAccount,
     name: identity.name,
     email: identity.email,
     full_name: identity.fullName || undefined,
     username: creds.username || identity.email,
-    password: creds.password,
+    // Only write a plaintext password when one was actually supplied, so a
+    // password_command or oauth2 account is not downgraded by an edit that
+    // never touched its credentials. When one *is* supplied, drop
+    // password_command — it would otherwise take precedence at load time and
+    // silently defeat the password the user just typed.
+    ...(creds.password ? { password: creds.password, password_command: undefined } : {}),
     imap: {
+      ...existingAccount?.imap,
       host: server.imapHost,
       port: server.imapPort,
       tls: server.imapTls,
       starttls: !server.imapTls,
-      verify_ssl: true,
+      verify_ssl: existingAccount?.imap.verify_ssl ?? true,
     },
     smtp: {
+      ...existingAccount?.smtp,
       host: server.smtpHost,
       port: server.smtpPort,
       tls: server.smtpTls,
       starttls: server.smtpStarttls,
-      verify_ssl: true,
+      verify_ssl: existingAccount?.smtp.verify_ssl ?? true,
       pool: {
         enabled: server.smtpPoolEnabled,
         max_connections: server.smtpPoolMaxConnections,
@@ -687,7 +698,7 @@ async function editAccount(nameArg?: string): Promise<void> {
   }
 
   // Save updated account
-  const updatedAccount = buildRawAccount(identity, creds, server);
+  const updatedAccount = buildRawAccount(identity, creds, server, current);
   const updatedAccounts = [...accounts];
   updatedAccounts[accountIndex] = updatedAccount;
 

--- a/src/cli/config-commands.ts
+++ b/src/cli/config-commands.ts
@@ -79,7 +79,15 @@ async function showConfig(): Promise<void> {
           : 'disabled'
       }`,
     );
-    console.log(`  password = ${'•'.repeat(8)}\n`);
+    if (account.oauth2) {
+      console.log(`  auth     = oauth2 (${account.oauth2.provider})\n`);
+    } else if (account.passwordCommand) {
+      // The command is not a secret and seeing it is the whole debugging value.
+      console.log(`  auth     = password_command`);
+      console.log(`  command  = ${account.passwordCommand}\n`);
+    } else {
+      console.log(`  password = ${'•'.repeat(8)}\n`);
+    }
   });
 }
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -136,6 +136,121 @@ read_only = true
   });
 
   // -------------------------------------------------------------------------
+  // password_command
+  // -------------------------------------------------------------------------
+
+  // These use POSIX shell builtins (printf, echo, exit, true, 1>&2) rather
+  // than mocking node:child_process, so the parts worth covering — newline
+  // trimming, stdout/stderr separation, error shape — are actually exercised.
+  describe('password_command', () => {
+    async function loadWithAccountBody(body: string) {
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(
+        configPath,
+        `
+[[accounts]]
+name = "test"
+email = "test@example.com"
+${body}
+
+[accounts.imap]
+host = "imap.example.com"
+
+[accounts.smtp]
+host = "smtp.example.com"
+`,
+        'utf-8',
+      );
+      return loadConfig(configPath);
+    }
+
+    it('resolves the account password by running password_command', async () => {
+      const config = await loadWithAccountBody('password_command = "printf secret123"');
+
+      expect(config.accounts[0]?.password).toBe('secret123');
+    });
+
+    it('trims trailing newline from command output', async () => {
+      const config = await loadWithAccountBody('password_command = "echo secret123"');
+
+      expect(config.accounts[0]?.password).toBe('secret123');
+    });
+
+    it('prefers password_command over an inline password', async () => {
+      const config = await loadWithAccountBody(
+        'password = "inline"\npassword_command = "printf from-command"',
+      );
+
+      expect(config.accounts[0]?.password).toBe('from-command');
+    });
+
+    it('resolves password_command for every account', async () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(
+        configPath,
+        `
+[[accounts]]
+name = "first"
+email = "first@example.com"
+password_command = "printf first-secret"
+
+[accounts.imap]
+host = "imap.example.com"
+
+[accounts.smtp]
+host = "smtp.example.com"
+
+[[accounts]]
+name = "second"
+email = "second@example.com"
+password_command = "printf second-secret"
+
+[accounts.imap]
+host = "imap.example.com"
+
+[accounts.smtp]
+host = "smtp.example.com"
+`,
+        'utf-8',
+      );
+
+      const config = await loadConfig(configPath);
+
+      expect(config.accounts[0]?.password).toBe('first-secret');
+      expect(config.accounts[1]?.password).toBe('second-secret');
+    });
+
+    it('names the failing account when password_command exits non-zero', async () => {
+      await expect(loadWithAccountBody('password_command = "exit 7"')).rejects.toThrow(
+        'password_command for account "test"',
+      );
+    });
+
+    it('does not leak command stdout into the error message', async () => {
+      const loading = loadWithAccountBody('password_command = "echo leaked-secret; exit 1"');
+
+      await expect(loading).rejects.toThrow('password_command for account "test"');
+      await expect(loading).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.not.stringContaining('leaked-secret') as unknown as string,
+        }),
+      );
+    });
+
+    it('includes command stderr in the failure message', async () => {
+      await expect(
+        loadWithAccountBody('password_command = "echo vault-is-locked 1>&2; exit 1"'),
+      ).rejects.toThrow('vault-is-locked');
+    });
+
+    it('throws when password_command produces no output', async () => {
+      await expect(loadWithAccountBody('password_command = "true"')).rejects.toThrow(
+        'produced no output',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // loadConfig from environment variables
   // -------------------------------------------------------------------------
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -358,6 +358,38 @@ host = "smtp.example.com"
   // configExists
   // -------------------------------------------------------------------------
 
+  describe('saveConfig permissions', () => {
+    it('writes the config file readable only by its owner', async () => {
+      const configPath = path.join(tmpDir, 'perms', 'config.toml');
+
+      await saveConfig({ settings: {}, accounts: [] } as never, configPath);
+
+      const mode = (await fs.stat(configPath)).mode.toString(8).slice(-3);
+      expect(mode).toBe('600');
+    });
+
+    it('creates the config directory readable only by its owner', async () => {
+      const dir = path.join(tmpDir, 'perms-dir');
+
+      await saveConfig({ settings: {}, accounts: [] } as never, path.join(dir, 'config.toml'));
+
+      const mode = (await fs.stat(dir)).mode.toString(8).slice(-3);
+      expect(mode).toBe('700');
+    });
+
+    // mode on writeFile applies only at creation, so an existing config with
+    // looser permissions — the case that actually leaks — needs chmod.
+    it('tightens an existing config that was left world-readable', async () => {
+      const configPath = path.join(tmpDir, 'loose.toml');
+      await fs.writeFile(configPath, '', 'utf-8');
+      await fs.chmod(configPath, 0o644);
+
+      await saveConfig({ settings: {}, accounts: [] } as never, configPath);
+
+      expect((await fs.stat(configPath)).mode.toString(8).slice(-3)).toBe('600');
+    });
+  });
+
   describe('configExists', () => {
     it('returns true for existing file', async () => {
       const configPath = path.join(tmpDir, 'config.toml');

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -35,6 +35,7 @@ describe('Config Loader', () => {
     for (const key of [
       'MCP_EMAIL_ADDRESS',
       'MCP_EMAIL_PASSWORD',
+      'MCP_EMAIL_PASSWORD_COMMAND',
       'MCP_EMAIL_IMAP_HOST',
       'MCP_EMAIL_SMTP_HOST',
       'MCP_EMAIL_READ_ONLY',
@@ -170,6 +171,18 @@ host = "smtp.example.com"
       expect(config.accounts[0]?.password).toBe('secret123');
     });
 
+    it('exposes the command on the account for diagnostics', async () => {
+      const config = await loadWithAccountBody('password_command = "printf secret123"');
+
+      expect(config.accounts[0]?.passwordCommand).toBe('printf secret123');
+    });
+
+    it('leaves passwordCommand unset for a plaintext account', async () => {
+      const config = await loadWithAccountBody('password = "secret"');
+
+      expect(config.accounts[0]?.passwordCommand).toBeUndefined();
+    });
+
     it('trims trailing newline from command output', async () => {
       const config = await loadWithAccountBody('password_command = "echo secret123"');
 
@@ -267,6 +280,30 @@ host = "smtp.example.com"
       expect(config.accounts[0].email).toBe('env@example.com');
       expect(config.accounts[0].imap.host).toBe('imap.env.com');
       expect(config.accounts[0].smtp.host).toBe('smtp.env.com');
+    });
+
+    it('accepts MCP_EMAIL_PASSWORD_COMMAND instead of MCP_EMAIL_PASSWORD', async () => {
+      process.env.MCP_EMAIL_ADDRESS = 'env@example.com';
+      process.env.MCP_EMAIL_PASSWORD_COMMAND = 'printf env-secret';
+      process.env.MCP_EMAIL_IMAP_HOST = 'imap.env.com';
+      process.env.MCP_EMAIL_SMTP_HOST = 'smtp.env.com';
+
+      const config = await loadConfig(path.join(tmpDir, 'nonexistent.toml'));
+
+      expect(config.accounts[0].password).toBe('env-secret');
+      expect(config.accounts[0].passwordCommand).toBe('printf env-secret');
+    });
+
+    it('falls back to the config file when no credential env var is set', async () => {
+      process.env.MCP_EMAIL_ADDRESS = 'env@example.com';
+      process.env.MCP_EMAIL_IMAP_HOST = 'imap.env.com';
+      process.env.MCP_EMAIL_SMTP_HOST = 'smtp.env.com';
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(configPath, MINIMAL_TOML, 'utf-8');
+
+      const config = await loadConfig(configPath);
+
+      expect(config.accounts[0].email).toBe('test@example.com');
     });
 
     it('reads read_only from MCP_EMAIL_READ_ONLY', async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 
 import { parse as parseTOML, stringify as stringifyTOML } from 'smol-toml';
 import type { AccountConfig, AppConfig, HookRule, OAuth2Config } from '../types/index.js';
+import resolvePasswordCommand from './password-command.js';
 import type { RawAccountConfig, RawAppConfig } from './schema.js';
 import { AppConfigFileSchema } from './schema.js';
 import { CONFIG_FILE, xdg } from './xdg.js';
@@ -152,13 +153,20 @@ function normalizeOAuth2(raw: NonNullable<RawAccountConfig['oauth2']>): OAuth2Co
   };
 }
 
-function normalizeAccount(raw: RawAccountConfig): AccountConfig {
+async function normalizeAccount(raw: RawAccountConfig): Promise<AccountConfig> {
+  // password_command wins over an inline password: the explicit, more secure
+  // field must not be silently defeated by a plaintext line left behind
+  // during migration.
+  const password = raw.password_command
+    ? await resolvePasswordCommand(raw.password_command, raw.name)
+    : raw.password;
+
   return {
     name: raw.name,
     email: raw.email,
     fullName: raw.full_name,
     username: raw.username ?? raw.email,
-    password: raw.password,
+    password,
     oauth2: raw.oauth2 ? normalizeOAuth2(raw.oauth2) : undefined,
     imap: {
       host: raw.imap.host,
@@ -205,7 +213,7 @@ function normalizeHookRule(raw: {
   };
 }
 
-function normalizeConfig(raw: RawAppConfig): AppConfig {
+async function normalizeConfig(raw: RawAppConfig): Promise<AppConfig> {
   return {
     settings: {
       rateLimit: raw.settings.rate_limit,
@@ -237,7 +245,7 @@ function normalizeConfig(raw: RawAppConfig): AppConfig {
         calendarConfirm: raw.settings.hooks.calendar_confirm ?? true,
       },
     },
-    accounts: raw.accounts.map(normalizeAccount),
+    accounts: await Promise.all(raw.accounts.map(normalizeAccount)),
   };
 }
 
@@ -349,6 +357,10 @@ full_name = "Your Name"
 # username defaults to email if omitted
 # username = "you@example.com"
 password = "your-app-password"
+# ...or resolve it from an external command instead (stdout is trimmed, runs at startup):
+# password_command = "security find-generic-password -s email-mcp-personal -w"
+# password_command = "bw get password personal-email"
+# password_command = "op read 'op://Private/personal-email/password'"
 
 [accounts.imap]
 host = "imap.example.com"

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -305,9 +305,13 @@ export async function saveConfig(
   filePath: string = CONFIG_FILE,
 ): Promise<void> {
   const dir = path.dirname(filePath);
-  await fs.mkdir(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
   const toml = stringifyTOML(config as Record<string, unknown>);
-  await fs.writeFile(filePath, toml, 'utf-8');
+  await fs.writeFile(filePath, toml, { encoding: 'utf-8', mode: 0o600 });
+  // `mode` above only applies when the file is created, and is masked by umask.
+  // chmod also tightens a config that already exists with looser permissions —
+  // which is the case that matters, since that file may hold a password.
+  await fs.chmod(filePath, 0o600);
 }
 
 /**

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -21,6 +21,7 @@ import { CONFIG_FILE, xdg } from './xdg.js';
 function loadFromEnv(): RawAppConfig | null {
   const email = process.env.MCP_EMAIL_ADDRESS;
   const password = process.env.MCP_EMAIL_PASSWORD;
+  const passwordCommand = process.env.MCP_EMAIL_PASSWORD_COMMAND;
   const imapHost = process.env.MCP_EMAIL_IMAP_HOST;
   const smtpHost = process.env.MCP_EMAIL_SMTP_HOST;
 
@@ -28,9 +29,9 @@ function loadFromEnv(): RawAppConfig | null {
     return null;
   }
 
-  // Need either password or OAuth2 env vars
+  // Need a password, a password command, or OAuth2 env vars
   const oauth2Provider = process.env.MCP_EMAIL_OAUTH2_PROVIDER;
-  if (!password && !oauth2Provider) {
+  if (!password && !passwordCommand && !oauth2Provider) {
     return null;
   }
 
@@ -98,6 +99,7 @@ function loadFromEnv(): RawAppConfig | null {
         full_name: process.env.MCP_EMAIL_FULL_NAME,
         username: process.env.MCP_EMAIL_USERNAME,
         password,
+        password_command: passwordCommand,
         oauth2,
         imap: {
           host: imapHost,
@@ -167,6 +169,7 @@ async function normalizeAccount(raw: RawAccountConfig): Promise<AccountConfig> {
     fullName: raw.full_name,
     username: raw.username ?? raw.email,
     password,
+    passwordCommand: raw.password_command,
     oauth2: raw.oauth2 ? normalizeOAuth2(raw.oauth2) : undefined,
     imap: {
       host: raw.imap.host,

--- a/src/config/password-command.ts
+++ b/src/config/password-command.ts
@@ -1,0 +1,99 @@
+/**
+ * Resolve an account password by executing an external command.
+ *
+ * Lets users keep secrets in a password manager (Bitwarden CLI, the macOS
+ * Keychain, 1Password, ...) instead of in plaintext in config.toml.
+ */
+
+import { exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execCallback);
+
+/** Max wall-clock time a password command may run before it is killed. */
+const COMMAND_TIMEOUT_MS = 10_000;
+
+/** Max bytes captured from the child's stdout/stderr. */
+const MAX_OUTPUT_BYTES = 1024 * 1024;
+
+/** Max characters of child stderr echoed back in error messages. */
+const STDERR_EXCERPT_LIMIT = 400;
+
+/** The subset of an exec rejection we rely on. */
+interface CommandFailure {
+  killed?: boolean;
+  code?: number | string | null;
+  stderr?: string;
+}
+
+/**
+ * Trim and truncate child stderr so it can be safely quoted in an error.
+ * The resolved password only ever travels over stdout, never stderr.
+ */
+function stderrExcerpt(stderr: string | undefined): string {
+  const trimmed = (stderr ?? '').trim();
+  if (trimmed.length === 0) {
+    return '';
+  }
+  return trimmed.length > STDERR_EXCERPT_LIMIT
+    ? `${trimmed.slice(0, STDERR_EXCERPT_LIMIT)}…`
+    : trimmed;
+}
+
+/**
+ * Run the command through the platform shell.
+ *
+ * `options.env` is deliberately omitted so the child inherits `process.env` —
+ * that is how `BW_SESSION`, `OP_SERVICE_ACCOUNT_TOKEN` and `PATH` reach it.
+ * `options.stdio` is likewise omitted: exec always gives the child pipes, and
+ * inherited fds would corrupt the MCP channel on the stdio transport.
+ */
+async function runCommand(
+  command: string,
+  accountName: string,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await exec(command, {
+      encoding: 'utf8',
+      timeout: COMMAND_TIMEOUT_MS,
+      maxBuffer: MAX_OUTPUT_BYTES,
+      windowsHide: true,
+    });
+  } catch (error) {
+    // Never re-throw the exec error itself: its message embeds the full
+    // command line, and for some failure modes the captured stdout too.
+    const failure = error as CommandFailure;
+    const reason = failure.killed
+      ? `timed out after ${COMMAND_TIMEOUT_MS / 1000}s — does it wait for input? Unlock your vault before starting email-mcp.`
+      : `exited with code ${String(failure.code ?? 'unknown')}`;
+    const detail = stderrExcerpt(failure.stderr);
+    throw new Error(
+      `password_command for account "${accountName}" ${reason}${detail ? `\n  stderr: ${detail}` : ''}`,
+    );
+  }
+}
+
+/**
+ * Execute `command` and return its trimmed stdout as the account password.
+ *
+ * @param command Shell command line, e.g. `bw get password personal-email`.
+ * @param accountName Account the command belongs to, used in error messages.
+ */
+export default async function resolvePasswordCommand(
+  command: string,
+  accountName: string,
+): Promise<string> {
+  const { stdout, stderr } = await runCommand(command, accountName);
+  // Password managers print a trailing newline (`bw get password`,
+  // `security find-generic-password -w`, `op read`).
+  const password = stdout.trim();
+
+  if (password.length === 0) {
+    const detail = stderrExcerpt(stderr);
+    throw new Error(
+      `password_command for account "${accountName}" produced no output on stdout${detail ? `\n  stderr: ${detail}` : ''}`,
+    );
+  }
+
+  return password;
+}

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -92,6 +92,37 @@ describe('AccountConfigSchema', () => {
     );
   });
 
+  it('accepts password_command instead of password', () => {
+    const result = AccountConfigSchema.parse(
+      validAccount({ password: undefined, password_command: 'printf secret123' }),
+    );
+    expect(result.password_command).toBe('printf secret123');
+    expect(result.password).toBeUndefined();
+  });
+
+  it('accepts both password and password_command', () => {
+    const result = AccountConfigSchema.parse(
+      validAccount({ password_command: 'printf secret123' }),
+    );
+    expect(result.password).toBe('secret');
+    expect(result.password_command).toBe('printf secret123');
+  });
+
+  it('rejects an empty password_command', () => {
+    expect(() =>
+      AccountConfigSchema.parse(validAccount({ password: undefined, password_command: '' })),
+    ).toThrow('password_command cannot be empty');
+  });
+
+  // Guards against "simplifying" the refine back into a ?? chain, which would
+  // short-circuit on the non-nullish empty string and reject a valid account.
+  it('accepts an empty password when password_command is set', () => {
+    const result = AccountConfigSchema.parse(
+      validAccount({ password: '', password_command: 'printf secret123' }),
+    );
+    expect(result.password_command).toBe('printf secret123');
+  });
+
   it('rejects missing name', () => {
     expect(() => AccountConfigSchema.parse(validAccount({ name: '' }))).toThrow();
   });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -49,13 +49,18 @@ export const AccountConfigSchema = z
     full_name: z.string().optional(),
     username: z.string().optional(),
     password: z.string().optional(),
+    /** Shell command whose trimmed stdout is used as the password. */
+    password_command: z.string().min(1, 'password_command cannot be empty').optional(),
     oauth2: OAuth2ConfigSchema.optional(),
     imap: ImapConfigSchema,
     smtp: SmtpConfigSchema,
   })
-  .refine((data) => data.password ?? data.oauth2, {
-    message: 'Either password or oauth2 config is required',
-  });
+  // Boolean() rather than a ?? chain: ?? short-circuits on non-nullish, so a
+  // leftover `password = ""` would swallow a valid password_command.
+  .refine(
+    (data) => Boolean(data.password) || Boolean(data.password_command) || Boolean(data.oauth2),
+    { message: 'Either password_command, password or oauth2 config is required' },
+  );
 
 export const WatcherConfigSchema = z.object({
   enabled: z.boolean().default(false),

--- a/src/tools/health.tool.ts
+++ b/src/tools/health.tool.ts
@@ -9,6 +9,14 @@ import { z } from 'zod';
 
 import type ConnectionManager from '../connections/manager.js';
 import type ImapService from '../services/imap.service.js';
+import type { AccountConfig } from '../types/index.js';
+
+/** How the account actually authenticates, as configured. */
+function authType(cfg: AccountConfig): 'oauth2' | 'password_command' | 'password' {
+  if (cfg.oauth2) return 'oauth2';
+  if (cfg.passwordCommand) return 'password_command';
+  return 'password';
+}
 
 export default function registerHealthTools(
   server: McpServer,
@@ -30,7 +38,7 @@ export default function registerHealthTools(
           const cfg = connections.getAccount(name);
           const result: Record<string, unknown> = {
             name,
-            auth_type: cfg.oauth2 ? 'oauth2' : 'password',
+            auth_type: authType(cfg),
           };
 
           // IMAP health

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,8 @@ export interface AccountConfig {
   fullName?: string;
   username: string;
   password?: string;
+  /** Command that produced `password`. Diagnostic only — never the secret. */
+  passwordCommand?: string;
   oauth2?: OAuth2Config;
   imap: ImapConfig;
   smtp: SmtpConfig;


### PR DESCRIPTION
## What

Adds an optional `password_command` field to account config, so an account password can be produced by an external command — a password manager CLI, the macOS Keychain, 1Password — instead of sitting in plaintext in `config.toml`.

Accounts using a plaintext `password` are unaffected.

```toml
[[accounts]]
name = "personal"
email = "you@example.com"
password_command = "security find-generic-password -s email-mcp-personal -w"
```

## How it works

The command runs once at load, through the platform shell, and its trimmed stdout becomes the password.

- `options.env` is omitted so the child inherits `process.env` — that is how `BW_SESSION` and `OP_SERVICE_ACCOUNT_TOKEN` reach it.
- `stdio` is left to `exec`'s pipes. On the stdio transport the server's stdout **is** the MCP channel, so an inherited fd would let a chatty vault CLI corrupt the protocol.
- Failures name the account and quote the child's stderr, never its stdout — the secret only ever travels over stdout.
- `normalizeAccount` and `normalizeConfig` become async so resolution uses `promisify(exec)` and runs in parallel across accounts. Both are private and `loadConfig` was already async, so no caller changes.

Resolution happens at load rather than at connect: the five `account.password` reads are all *reconnect* paths, and the watcher reconnects with exponential backoff, so lazy resolution would hammer the vault and re-prompt for biometrics on every flap. The trade-off — vault unlocked at startup, restart to rotate — matches what the plaintext field already implies.

## Two pre-existing bugs fixed along the way

**`account edit` destroyed fields it never collected.** `buildRawAccount` rebuilt each account from a closed field list and `editAccount` replaced the array slot wholesale, so any key absent from that literal was dropped on *every* edit, whichever field the user chose. This would have destroyed `password_command` on first use — and it already destroyed `oauth2` and both `verify_ssl` flags the same way.

**`config show` printed a masked password unconditionally**, which was already wrong for OAuth2 accounts.

## Config file permissions

`saveConfig` wrote the config with whatever umask allowed — `0644` on a default setup, readable by every process on the machine, for a file that can hold a password. The directory is now created `0700` and the file written `0600`.

Those modes only apply at creation and are masked by umask, so the file is also `chmod`'d on every save: an existing config left world-readable is exactly the case that leaks, and it would otherwise never be fixed. The directory is not `chmod`'d, since a caller passing a custom path may point at a shared one.

Credit to #8 by @rupjae, which raised this alongside a macOS-specific Keychain integration. This takes the permission half, which helps every platform and every user — including those keeping a plaintext password. The Keychain half is superseded by `password_command`, which covers the same case plus Bitwarden, 1Password and anything else with a CLI.

## Also included

`check_health` reports `auth_type: "password_command"` instead of claiming `"password"`; `MCP_EMAIL_PASSWORD_COMMAND` gives the environment path the same option and joins the guard deciding whether env config is complete; `account add` and `account edit` offer a command as a credential source, with `buildTestAccount` resolving it so the connection test exercises the real credential rather than an empty password; `SECURITY.md` recommends it over a plaintext password.

## Testing

`pnpm check`, `pnpm typecheck`, `pnpm test` (173), `pnpm build` all clean. Integration suite green (9 files, 66 tests, GreenMail).

Unit coverage added for the schema refine — including a guard against reintroducing the `??` chain, which an empty-string `password` would short-circuit — command resolution, the error shape (asserting the resolved secret never reaches the message), and `credentialFields`, exported precisely because it is the function whose regression would silently destroy a config.

Verified end to end against four live accounts across two providers, migrated from plaintext to the macOS Keychain: all four resolve and authenticate, including from the restricted environment a GUI-launched MCP client provides — no `USER`, system `PATH` only. That last point is why the documented recipe writes an explicit username rather than `$USER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

