### PR TITLE
docs(readme): document list_events and list_reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Features:
 
 ## API
 
-### Tools (47)
+### Tools (49)
 
 #### Read (14)
 
@@ -710,7 +710,7 @@ Features:
 | `check_notification_setup` | Diagnose desktop notification support and provide setup instructions |
 | `test_notification` | Send a test notification to verify OS permissions are configured |
 
-#### Calendar & Reminders (6)
+#### Calendar & Reminders (8)
 
 | Tool | Description |
 |------|-------------|
@@ -720,6 +720,8 @@ Features:
 | `create_reminder` | Create a reminder in macOS Reminders.app from an email |
 | `list_calendars` | List all available local calendars |
 | `check_calendar_permissions` | Check whether the local calendar is accessible |
+| `list_events` | List local calendar events in a time range, optionally filtered by title or calendar |
+| `list_reminders` | List local reminders, optionally filtered by title or list name |
 
 ### Prompts (7)
 


### PR DESCRIPTION
## What

`list_events` and `list_reminders` are registered in `src/tools/calendar.tool.ts` but appear in no README table. The tool counts therefore read 47 against 49 actually exposed, and a client reading the README had no way to learn the two tools exist.

Adds both rows and corrects the counts.

## Verification

Comparing every `server.tool(...)` registration against the README tables:

```
non documentés : aucun
total annoncé 49 · somme des sections 49 · outils réels 49 → cohérent
```

The header, the per-section totals and the registered count now all agree.

Documentation only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
