### PR TITLE
fix(tools): accept numeric parameters sent as strings

### DIFF
--- a/src/tools/bulk.tool.ts
+++ b/src/tools/bulk.tool.ts
@@ -20,7 +20,7 @@ export default function registerBulkTools(server: McpServer, imapService: ImapSe
         .enum(['mark_read', 'mark_unread', 'flag', 'unflag', 'move', 'delete'])
         .describe('Bulk action to perform'),
       ids: z
-        .array(z.number().int())
+        .array(z.coerce.number().int())
         .min(1)
         .max(100)
         .describe('Array of email UIDs (max 100). Get UIDs from list_emails or search_emails.'),

--- a/src/tools/calendar.tool.ts
+++ b/src/tools/calendar.tool.ts
@@ -112,7 +112,7 @@ export default function registerCalendarTools(
         .string()
         .optional()
         .describe('Target calendar name (empty = default calendar)'),
-      alarm_minutes: z
+      alarm_minutes: z.coerce
         .number()
         .int()
         .min(0)
@@ -385,7 +385,7 @@ export default function registerCalendarTools(
           'Show events on or before this date (ISO 8601, e.g. 2026-02-28). Defaults to 30 days from now.',
         ),
       calendar_name: z.string().optional().describe('Restrict to a specific calendar by name'),
-      limit: z
+      limit: z.coerce
         .number()
         .int()
         .min(1)
@@ -453,7 +453,7 @@ export default function registerCalendarTools(
         .boolean()
         .default(false)
         .describe('Include completed reminders (default: false)'),
-      limit: z
+      limit: z.coerce
         .number()
         .int()
         .min(1)

--- a/src/tools/contacts.tool.ts
+++ b/src/tools/contacts.tool.ts
@@ -14,7 +14,7 @@ export default function registerContactsTools(server: McpServer, imapService: Im
     {
       account: z.string().describe('Account name from list_accounts'),
       mailbox: z.string().optional().describe('Mailbox to scan (default: INBOX)'),
-      limit: z
+      limit: z.coerce
         .number()
         .int()
         .min(1)

--- a/src/tools/drafts.tool.ts
+++ b/src/tools/drafts.tool.ts
@@ -80,7 +80,7 @@ export default function registerDraftTools(
     'Send an existing draft email and remove it from Drafts. The draft is fetched, sent via SMTP, then deleted. Use list_emails with the Drafts mailbox to find draft IDs.',
     {
       account: z.string().describe('Account name from list_accounts'),
-      id: z.number().int().describe('Draft email UID (from list_emails on Drafts mailbox)'),
+      id: z.coerce.number().int().describe('Draft email UID (from list_emails on Drafts mailbox)'),
       mailbox: z.string().optional().describe('Drafts folder path (auto-detected if omitted)'),
     },
     { readOnlyHint: false, destructiveHint: true },

--- a/src/tools/emails.tool.ts
+++ b/src/tools/emails.tool.ts
@@ -123,8 +123,8 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
     {
       account: z.string().describe('Account name from list_accounts'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
-      page: z.number().int().min(1).default(1).describe('Page number'),
-      pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
+      page: z.coerce.number().int().min(1).default(1).describe('Page number'),
+      pageSize: z.coerce.number().int().min(1).max(100).default(20).describe('Results per page'),
       since: z.string().optional().describe('Show emails after this date (ISO 8601)'),
       before: z.string().optional().describe('Show emails before this date (ISO 8601)'),
       from: z.string().optional().describe('Filter by sender address or name'),
@@ -203,7 +203,7 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .describe(
           'Body format: full=raw (default), text=plain text (strips HTML), stripped=plain text without quoted replies or signatures',
         ),
-      maxLength: z
+      maxLength: z.coerce
         .number()
         .int()
         .min(100)
@@ -296,7 +296,7 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .describe(
           'Body format (default: text — strips HTML for efficient AI reading). Use stripped to also remove quoted replies.',
         ),
-      maxLength: z
+      maxLength: z.coerce
         .number()
         .int()
         .min(100)
@@ -431,15 +431,15 @@ export default function registerEmailsTools(server: McpServer, imapService: Imap
         .default('')
         .describe('Search keyword (omit or leave empty to use filters only)'),
       mailbox: z.string().default('INBOX').describe('Mailbox path (default: INBOX)'),
-      page: z.number().int().min(1).default(1).describe('Page number'),
-      pageSize: z.number().int().min(1).max(100).default(20).describe('Results per page'),
+      page: z.coerce.number().int().min(1).default(1).describe('Page number'),
+      pageSize: z.coerce.number().int().min(1).max(100).default(20).describe('Results per page'),
       to: z.string().optional().describe('Filter by recipient address'),
       has_attachment: z
         .boolean()
         .optional()
         .describe('Filter: true=has attachments, false=no attachments'),
-      larger_than: z.number().optional().describe('Minimum email size in KB'),
-      smaller_than: z.number().optional().describe('Maximum email size in KB'),
+      larger_than: z.coerce.number().optional().describe('Minimum email size in KB'),
+      smaller_than: z.coerce.number().optional().describe('Maximum email size in KB'),
       answered: z.boolean().optional().describe('Filter: true=replied, false=not replied'),
     },
     { readOnlyHint: true, destructiveHint: false },

--- a/src/tools/numeric-params.test.ts
+++ b/src/tools/numeric-params.test.ts
@@ -1,0 +1,79 @@
+/**
+ * MCP callers routinely send every parameter as a string. A bare `z.number()`
+ * rejects "20", which breaks the tool for those clients before the handler ever
+ * runs — the failure is silent from the caller's point of view.
+ *
+ * This walks the real tool schemas and asserts the property that prevents it:
+ * a field that accepts the number 5 must also accept the string "5".
+ */
+
+import type { ZodTypeAny } from 'zod';
+
+import registerAttachmentTools from './attachments.tool.js';
+import registerBulkTools from './bulk.tool.js';
+import registerCalendarTools from './calendar.tool.js';
+import registerContactsTools from './contacts.tool.js';
+import registerDraftTools from './drafts.tool.js';
+import registerEmailsTools from './emails.tool.js';
+import registerThreadTools from './thread.tool.js';
+
+type Shape = Record<string, ZodTypeAny>;
+
+/** Captures the schema each tool registers, without running a real server. */
+function collectSchemas(register: (server: never, service: never) => void): Map<string, Shape> {
+  const schemas = new Map<string, Shape>();
+  const server = {
+    tool: (name: string, ...rest: unknown[]) => {
+      const shape = rest.find(
+        (arg) => arg && typeof arg === 'object' && !Array.isArray(arg) && !('_def' in arg),
+      );
+      if (shape) schemas.set(name, shape as Shape);
+    },
+  };
+  register(server as never, {} as never);
+  return schemas;
+}
+
+const REGISTRARS = {
+  attachments: registerAttachmentTools,
+  bulk: registerBulkTools,
+  calendar: registerCalendarTools,
+  contacts: registerContactsTools,
+  drafts: registerDraftTools,
+  emails: registerEmailsTools,
+  thread: registerThreadTools,
+};
+
+/** Every (tool, field) pair across the registrars above. */
+function everyField(): { tool: string; field: string; schema: ZodTypeAny }[] {
+  return Object.values(REGISTRARS).flatMap((register) =>
+    [...collectSchemas(register as never).entries()].flatMap(([tool, shape]) =>
+      Object.entries(shape).map(([field, schema]) => ({ tool, field, schema })),
+    ),
+  );
+}
+
+describe('numeric tool parameters accept strings', () => {
+  it('finds tools to check, so a broken harness cannot pass vacuously', () => {
+    const fields = everyField();
+
+    expect(fields.length).toBeGreaterThan(20);
+    expect(new Set(fields.map((f) => f.tool)).size).toBeGreaterThan(5);
+  });
+
+  it('accepts a numeric string wherever it accepts a number', () => {
+    const offenders = everyField()
+      .filter(({ schema }) => schema.safeParse(5).success && !schema.safeParse('5').success)
+      .map(({ tool, field }) => `${tool}.${field}`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('accepts an array of numeric strings wherever it accepts an array of numbers', () => {
+    const offenders = everyField()
+      .filter(({ schema }) => schema.safeParse([5]).success && !schema.safeParse(['5']).success)
+      .map(({ tool, field }) => `${tool}.${field}`);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/tools/thread.tool.ts
+++ b/src/tools/thread.tool.ts
@@ -84,7 +84,7 @@ export default function registerThreadTools(server: McpServer, imapService: Imap
         .describe(
           'Body format: full=raw (default), text=plain text (strips HTML), stripped=plain text without quoted replies or signatures',
         ),
-      maxLength: z
+      maxLength: z.coerce
         .number()
         .int()
         .min(100)


### PR DESCRIPTION
## What

MCP callers routinely send every parameter as a string. A bare `z.number()` rejects `"20"`, so the tool fails before its handler runs and the caller sees a type error rather than a result.

## Scope

#28 reported this for the two pagination fields on `list_emails` and `search_emails`. The cause is not specific to them — it applies to every numeric parameter on the surface, so all fifteen are coerced: pagination, `limit`, `maxLength`, `alarm_minutes`, the size filters, the draft id, and the bulk id array.

## Testing

The regression test asserts the property rather than the source text: **a field that accepts the number 5 must also accept the string "5"**, and the array equivalent. It walks the real tool schemas by capturing what each registrar registers, so it covers fields added later without being updated.

Two things were checked about the test itself: it fails when a single coercion is removed, and it refuses to pass vacuously — one assertion requires that it found tools to check at all.

`pnpm check`, `pnpm typecheck`, `pnpm test`, `pnpm build` clean.

## Credit

#28 by @harcek for the diagnosis. This supersedes it by covering the whole class rather than the two reported instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
