### PR TITLE
fix(watcher): use a live OAuth token for IDLE instead of the password

### DIFF
--- a/src/connections/auth.test.ts
+++ b/src/connections/auth.test.ts
@@ -1,0 +1,59 @@
+import type { AccountConfig } from '../types/index.js';
+import buildImapAuth from './auth.js';
+
+const passwordAccount = {
+  name: 'plain',
+  email: 'a@example.com',
+  username: 'a@example.com',
+  password: 'secret',
+} as AccountConfig;
+
+const oauthAccount = {
+  name: 'work',
+  email: 'b@example.com',
+  username: 'b@example.com',
+  oauth2: { provider: 'google', clientId: 'id', clientSecret: 's', refreshToken: 'r' },
+} as AccountConfig;
+
+describe('buildImapAuth', () => {
+  it('uses the password for a password account', async () => {
+    expect(await buildImapAuth(passwordAccount)).toEqual({
+      user: 'a@example.com',
+      pass: 'secret',
+    });
+  });
+
+  it('ignores the OAuth service when the account does not use OAuth', async () => {
+    const oauthService = { getAccessToken: vi.fn() };
+
+    await buildImapAuth(passwordAccount, oauthService as never);
+
+    expect(oauthService.getAccessToken).not.toHaveBeenCalled();
+  });
+
+  // The regression this exists for: the IDLE watcher used to send
+  // account.password as the bearer token, which is undefined for an OAuth2
+  // account — so IDLE authenticated with nothing and failed silently.
+  it('fetches a live access token for an OAuth account', async () => {
+    const oauthService = { getAccessToken: vi.fn().mockResolvedValue('ya29.token') };
+
+    const auth = await buildImapAuth(oauthAccount, oauthService as never);
+
+    expect(auth).toEqual({ user: 'b@example.com', accessToken: 'ya29.token' });
+    expect(auth).not.toHaveProperty('pass');
+  });
+
+  it('never passes a password as an OAuth bearer token', async () => {
+    const hybrid = { ...oauthAccount, password: 'not-a-token' } as AccountConfig;
+    const oauthService = { getAccessToken: vi.fn().mockResolvedValue('ya29.token') };
+
+    const auth = await buildImapAuth(hybrid, oauthService as never);
+
+    expect(auth.accessToken).toBe('ya29.token');
+    expect(auth.accessToken).not.toBe('not-a-token');
+  });
+
+  it('fails loudly when an OAuth account has no OAuth service wired', async () => {
+    await expect(buildImapAuth(oauthAccount)).rejects.toThrow('no OAuth service is available');
+  });
+});

--- a/src/connections/auth.ts
+++ b/src/connections/auth.ts
@@ -1,0 +1,33 @@
+/**
+ * Build IMAP/SMTP auth credentials for an account.
+ *
+ * Shared so every connection path derives credentials the same way. Duplicating
+ * this is how the IDLE watcher came to pass `account.password` as an OAuth
+ * bearer token — undefined for an OAuth2 account, since such an account has no
+ * password to begin with.
+ */
+
+import type OAuthService from '../services/oauth.service.js';
+import type { AccountConfig } from '../types/index.js';
+
+export interface ImapAuth {
+  user: string;
+  pass?: string;
+  accessToken?: string;
+}
+
+export default async function buildImapAuth(
+  account: AccountConfig,
+  oauthService?: OAuthService,
+): Promise<ImapAuth> {
+  if (!account.oauth2) {
+    return { user: account.username, pass: account.password };
+  }
+  if (!oauthService) {
+    throw new Error(
+      `Account "${account.name}" is configured for OAuth2 but no OAuth service is available. ` +
+        'This is a wiring error, not a configuration one.',
+    );
+  }
+  return { user: account.username, accessToken: await oauthService.getAccessToken(account.oauth2) };
+}

--- a/src/connections/manager.ts
+++ b/src/connections/manager.ts
@@ -14,6 +14,7 @@ import { mcpLog } from '../logging.js';
 
 import type OAuthService from '../services/oauth.service.js';
 import type { AccountConfig } from '../types/index.js';
+import buildImapAuth from './auth.js';
 import type { IConnectionManager } from './types.js';
 
 type SmtpAuth =
@@ -76,14 +77,7 @@ export default class ConnectionManager implements IConnectionManager {
 
     const account = this.getAccount(accountName);
 
-    // Build auth config based on auth type
-    let auth: { user: string; pass?: string; accessToken?: string };
-    if (account.oauth2 && this.oauthService) {
-      const accessToken = await this.oauthService.getAccessToken(account.oauth2);
-      auth = { user: account.username, accessToken };
-    } else {
-      auth = { user: account.username, pass: account.password };
-    }
+    const auth = await buildImapAuth(account, this.oauthService);
 
     const client = new ImapFlow({
       host: account.imap.host,

--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ async function runServer(): Promise<void> {
   const localCalendarService = new LocalCalendarService();
   const remindersService = new RemindersService();
   const schedulerService = new SchedulerService(smtpService, imapService);
-  const watcherService = new WatcherService(config.settings.watcher, config.accounts);
+  const watcherService = new WatcherService(config.settings.watcher, config.accounts, oauthService);
   const hooksService = new HooksService(config.settings.hooks, imapService);
 
   const server = createServer();
@@ -207,7 +207,7 @@ async function runHttpServer(port: number): Promise<void> {
   const localCalendarService = new LocalCalendarService();
   const remindersService = new RemindersService();
   const schedulerService = new SchedulerService(smtpService, imapService);
-  const watcherService = new WatcherService(config.settings.watcher, config.accounts);
+  const watcherService = new WatcherService(config.settings.watcher, config.accounts, oauthService);
   const hooksService = new HooksService(config.settings.hooks, imapService);
 
   // Per-session factory: tools share service instances but each MCP session

--- a/src/services/watcher.service.ts
+++ b/src/services/watcher.service.ts
@@ -11,9 +11,11 @@
  */
 
 import { ImapFlow } from 'imapflow';
+import buildImapAuth from '../connections/auth.js';
 import { mcpLog } from '../logging.js';
 import type { AccountConfig, EmailMeta, WatcherConfig } from '../types/index.js';
 import eventBus from './event-bus.js';
+import type OAuthService from './oauth.service.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,9 +67,12 @@ export default class WatcherService {
 
   private accounts: AccountConfig[];
 
-  constructor(config: WatcherConfig, accounts: AccountConfig[]) {
+  private oauthService?: OAuthService;
+
+  constructor(config: WatcherConfig, accounts: AccountConfig[], oauthService?: OAuthService) {
     this.config = config;
     this.accounts = accounts;
+    this.oauthService = oauthService;
   }
 
   async start(): Promise<void> {
@@ -144,9 +149,7 @@ export default class WatcherService {
     if (!state || state.stopped) return;
 
     try {
-      const auth = state.account.oauth2
-        ? { user: state.account.username, accessToken: state.account.password }
-        : { user: state.account.username, pass: state.account.password };
+      const auth = await buildImapAuth(state.account, this.oauthService);
 
       const client = new ImapFlow({
         host: state.account.imap.host,


### PR DESCRIPTION
## What

The IMAP IDLE watcher built its own auth object and passed `account.password` as the OAuth bearer token:

```ts
const auth = state.account.oauth2
  ? { user: state.account.username, accessToken: state.account.password }
  : { user: state.account.username, pass: state.account.password };
```

An OAuth2 account has no password, so the watcher authenticated with `accessToken: undefined` and IDLE failed. Silently — the client is constructed with `logger: false`, so nothing reaches stderr. Where a password happened to sit alongside an `oauth2` block, it was sent to the server as a bearer token instead.

`ConnectionManager` already did this correctly, calling `oauthService.getAccessToken()`.

## Fix

Rather than copy that logic a third time, both paths now call a shared `buildImapAuth` — the duplication is why the two could drift apart in the first place. An OAuth2 account with no OAuth service wired now throws, instead of quietly degrading to password auth.

`WatcherService` takes the OAuth service as an optional third constructor argument, wired from both server entry points.

## Testing

Five unit tests on the shared builder, including the two that pin the regression: an OAuth account gets a live token and no `pass` field, and a password sitting alongside an `oauth2` block is never sent as a bearer token.

`pnpm check`, `pnpm typecheck`, `pnpm test`, `pnpm build` clean.

## Credit

Reported in #24 as one finding of a larger security pass. Extracted here on its own so it can be reviewed and merged without the rest of that PR, which is large and currently conflicting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
