### PR TITLE
fix(resources): make the stats resource as cheap as it claims

### DIFF
--- a/src/resources/stats.resource.ts
+++ b/src/resources/stats.resource.ts
@@ -36,17 +36,22 @@ export default function registerStatsResource(
     async (uri, { account }) => {
       const accountName = account as string;
 
-      // Lightweight STATUS query (fast, no envelope fetch)
-      const stats = await imapService.getEmailStats(accountName, 'INBOX', 'day');
+      // STATUS plus one SEARCH — two round trips, no envelope fetch. This used
+      // to call getEmailStats, which fetches envelope and body structure for
+      // every message in the period, while the comment here claimed it was a
+      // lightweight STATUS query.
+      const mailbox = await imapService.getMailboxSnapshot(accountName, 'INBOX');
 
       const quota = await imapService.getQuota(accountName);
 
       const snapshot = {
         account: accountName,
         date: new Date().toISOString().split('T')[0],
-        inbox_total: stats.totalReceived,
-        inbox_unread: stats.unreadCount,
-        inbox_today: stats.totalReceived,
+        // Previously the day's arrivals were reported as the mailbox total too,
+        // so inbox_total was wrong on any account with more than a day of mail.
+        inbox_total: mailbox.total,
+        inbox_unread: mailbox.unread,
+        inbox_today: mailbox.receivedToday,
         quota: quota ?? undefined,
       };
 

--- a/src/services/imap.service.test.ts
+++ b/src/services/imap.service.test.ts
@@ -166,3 +166,58 @@ describe('ImapService', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// getMailboxSnapshot
+// ---------------------------------------------------------------------------
+
+describe('ImapService.getMailboxSnapshot', () => {
+  let client: ReturnType<typeof createMockImapClient>;
+  let service: ImapService;
+
+  beforeEach(() => {
+    client = createMockImapClient();
+    service = new ImapService(createMockConnectionManager(client));
+  });
+
+  it('takes its totals from STATUS, not from a scan', async () => {
+    client.status.mockResolvedValue({ messages: 1709, unseen: 711 });
+    client.search.mockResolvedValue([101, 102, 103]);
+
+    const snapshot = await service.getMailboxSnapshot('test', 'INBOX');
+
+    expect(snapshot).toEqual({ total: 1709, unread: 711, receivedToday: 3 });
+    // No envelope or body-structure fetch: that was the old cost, on a code
+    // path documented as a lightweight STATUS query.
+    expect(client.fetch).not.toHaveBeenCalled();
+  });
+
+  it('counts today from midnight local time', async () => {
+    client.status.mockResolvedValue({ messages: 10, unseen: 0 });
+    client.search.mockResolvedValue([]);
+
+    await service.getMailboxSnapshot('test', 'INBOX');
+
+    const searchCriteria = client.search.mock.calls[0]?.[0] as { since: Date };
+    expect(searchCriteria.since.getHours()).toBe(0);
+    expect(searchCriteria.since.getMinutes()).toBe(0);
+    expect(searchCriteria.since.toDateString()).toBe(new Date().toDateString());
+  });
+
+  it('treats missing STATUS counters as zero', async () => {
+    client.status.mockResolvedValue({});
+    client.search.mockResolvedValue([]);
+
+    const snapshot = await service.getMailboxSnapshot('test', 'INBOX');
+
+    expect(snapshot).toEqual({ total: 0, unread: 0, receivedToday: 0 });
+  });
+
+  it('releases the mailbox lock even when the search fails', async () => {
+    client.status.mockResolvedValue({ messages: 1, unseen: 0 });
+    client.search.mockRejectedValue(new Error('NO [SERVERBUG]'));
+
+    await expect(service.getMailboxSnapshot('test', 'INBOX')).rejects.toThrow('NO [SERVERBUG]');
+    expect(client._releaseFn).toHaveBeenCalled();
+  });
+});

--- a/src/services/imap.service.ts
+++ b/src/services/imap.service.ts
@@ -18,6 +18,7 @@ import type {
   EmailStats,
   LabelInfo,
   Mailbox,
+  MailboxSnapshot,
   PaginatedResult,
   QuotaInfo,
   SenderStat,
@@ -1643,6 +1644,38 @@ export default class ImapService {
   // -------------------------------------------------------------------------
   // Quota
   // -------------------------------------------------------------------------
+
+  /**
+   * Mailbox counters without scanning the mailbox.
+   *
+   * STATUS answers the totals directly, and counting today's arrivals needs
+   * only the length of a SEARCH result — no envelopes, no body structure. Two
+   * round trips, whatever the mailbox holds.
+   */
+  async getMailboxSnapshot(accountName: string, mailbox = 'INBOX'): Promise<MailboxSnapshot> {
+    const client = await this.connections.getImapClient(accountName);
+    const safeMailbox = sanitizeMailboxName(mailbox);
+
+    const status = await client.status(safeMailbox, { messages: true, unseen: true });
+
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+
+    const lock = await client.getMailboxLock(safeMailbox);
+    let receivedToday = 0;
+    try {
+      const todayUids = await client.search({ since: startOfToday }, { uid: true });
+      receivedToday = Array.isArray(todayUids) ? todayUids.length : 0;
+    } finally {
+      lock.release();
+    }
+
+    return {
+      total: status.messages ?? 0,
+      unread: status.unseen ?? 0,
+      receivedToday,
+    };
+  }
 
   async getQuota(accountName: string): Promise<QuotaInfo | null> {
     const client = await this.connections.getImapClient(accountName);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -332,6 +332,16 @@ export interface EmailStats {
   avgPerDay: number;
 }
 
+/** Cheap mailbox counters, from STATUS plus one SEARCH. */
+export interface MailboxSnapshot {
+  /** Messages in the mailbox. */
+  total: number;
+  /** Unread messages in the mailbox. */
+  unread: number;
+  /** Messages whose internal date falls today. */
+  receivedToday: number;
+}
+
 export interface QuotaInfo {
   usedMb: number;
   totalMb: number;


### PR DESCRIPTION
### The `stats` resource is not the lightweight query it says it is

`stats.resource.ts` carries the comment *"Lightweight STATUS query (fast, no envelope fetch)"* directly above a call to `getEmailStats(...)`, which fetches `envelope`, `flags` and `bodyStructure` for **every message in the period**. Reading `email://{account}/stats` scans a day of mail to print three numbers.

There is also a correctness bug: `inbox_total` and `inbox_today` are assigned the same value, so `inbox_total` reports the day's arrivals rather than the mailbox total — wrong on any account holding more than a day of mail.

### Change

Adds `ImapService.getMailboxSnapshot()`: `STATUS` for the totals, one `SEARCH SINCE` for today's count. Two round trips whatever the mailbox holds, no envelopes, no body structure.

Four unit tests cover it, including that no `fetch` is issued, that missing STATUS counters read as zero, and that the mailbox lock is released when the search fails.

Verified on `develop`: `tsc --noEmit` clean, 154/154 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
